### PR TITLE
Technical debt: linting & code-quality fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1901,7 +1901,7 @@
       }
       if (cancelScan) break;
 
-      elScanLbl.textContent = `Capturing preset ${p} of 9…`;
+      elScanLbl.textContent = `Capturing preset ${p} of 11…`;
       const ok = await captureFrame(state.activeCam, p);
       if (!ok) {
         captureErrors.push(p);

--- a/public/index.html
+++ b/public/index.html
@@ -1217,7 +1217,6 @@
   (function initSSE() {
     const es = new EventSource('/events');
     es.onmessage = (e) => {
-      console.log('[SSE]', e.data);
       try {
         const ev = JSON.parse(e.data);
         if (ev.type === 'atem') {
@@ -1302,7 +1301,6 @@
 
   if (elGspFab && elGspPanel) {
     elGspFab.addEventListener('click', () => {
-      console.log('FAB clicked!');
       elGspPanel.classList.toggle('open');
     });
   }

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """PTZ Preset Control Server — VISCA over IP for AVIPAS cameras (with ATEM integration)."""
 
+from collections.abc import Generator
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 import glob
@@ -54,7 +55,7 @@ DEFAULT_SETTINGS = {
 
 
 # ── Settings ───────────────────────────────────────────────────────────────────
-def _ensure_dirs():
+def _ensure_dirs() -> None:
     os.makedirs(IMAGES_DIR, exist_ok=True)
 
 
@@ -139,7 +140,7 @@ def _make_ack(session_id: int, remote_id: int) -> bytes:
     return bytes([0x80, 0x0C]) + struct.pack(">HH", session_id, remote_id) + bytes(6)
 
 
-def _parse_header(data: bytes):
+def _parse_header(data: bytes) -> tuple[int, int]:
     word0 = struct.unpack(">H", data[0:2])[0]
     flags = (word0 >> 11) & 0x1F
     # bytes 10-11 = ATEM's sequence number for this packet (what we ACK back)
@@ -147,7 +148,7 @@ def _parse_header(data: bytes):
     return flags, seq_num
 
 
-def _parse_commands(payload: bytes):
+def _parse_commands(payload: bytes) -> Generator[tuple[str, bytes], None, None]:
     pos = 0
     while pos + 8 <= len(payload):
         cmd_len = struct.unpack(">H", payload[pos : pos + 2])[0]
@@ -159,7 +160,7 @@ def _parse_commands(payload: bytes):
         pos += cmd_len
 
 
-def _atem_loop():
+def _atem_loop() -> None:
     while True:
         cfg = load_settings().get("atem", {})
         if not cfg.get("enabled") or not cfg.get("ip", "").strip():
@@ -455,7 +456,7 @@ def _capture_url(url: str) -> bytes:
 
 
 # ── USB device capture ─────────────────────────────────────────────────────────
-def list_usb_devices() -> list:
+def list_usb_devices() -> list[dict]:
     devices = []
     if _IS_MACOS:
         try:

--- a/server.py
+++ b/server.py
@@ -649,9 +649,13 @@ class Handler(BaseHTTPRequestHandler):
             self._json(400, {"success": False, "message": "Invalid JSON"})
             return
         ip = str(data.get("ip", "")).strip()
-        port = int(data.get("port", 52381))
-        preset = max(0, int(data.get("preset", 0)))
-        camera = max(1, min(7, int(data.get("camera", 1))))
+        try:
+            port = int(data.get("port", 52381))
+            preset = max(0, int(data.get("preset", 0)))
+            camera = max(1, min(7, int(data.get("camera", 1))))
+        except (ValueError, TypeError):
+            self._json(400, {"success": False, "message": "Invalid numeric parameter"})
+            return
         if not ip:
             self._json(400, {"success": False, "message": "Camera IP is required"})
             return

--- a/server.py
+++ b/server.py
@@ -797,11 +797,11 @@ class Handler(BaseHTTPRequestHandler):
 
     def _serve_static(self, name: str):
         clean = os.path.normpath(name)
-        if clean.startswith(".."):
+        fpath = os.path.join(PUBLIC_DIR, clean)
+        if not os.path.abspath(fpath).startswith(os.path.abspath(PUBLIC_DIR) + os.sep):
             self.send_response(403)
             self.end_headers()
             return
-        fpath = os.path.join(PUBLIC_DIR, clean)
         if not os.path.isfile(fpath):
             self.send_response(404)
             self.end_headers()


### PR DESCRIPTION
## Summary

Five focused, independently-committed fixes surfaced by a broad code-quality audit:

- **Remove debug `console.log`** — deleted leftover `[SSE]` and `FAB clicked!` logs that fired on every page load / settings open (`public/index.html`)
- **Fix scan-label typo** — "Capturing preset N of 9…" corrected to "of 11…" to match the actual 0–11 loop range (`public/index.html`)
- **Guard numeric parsing in `_handle_recall()`** — `int()` calls on user-supplied `port`/`preset`/`camera` fields are now wrapped in `try/except (ValueError, TypeError)`, returning HTTP 400 instead of a 500 crash (`server.py`)
- **Add return-type annotations** — `_ensure_dirs`, `_parse_header`, `_parse_commands`, `_atem_loop`, and `list_usb_devices` now have explicit return types; adds `from collections.abc import Generator` (`server.py`)
- **Harden path-traversal check** — `_serve_static` now uses `os.path.abspath` containment instead of `startswith("..")`, which is immune to filenames that begin with `..` and correct on all platforms (`server.py`)

## Test plan

- [ ] `ruff check server.py` passes
- [ ] `python -m py_compile server.py` passes
- [ ] CI JS syntax check (`node --check` on extracted `<script>`) passes
- [ ] CI HTML well-formedness check passes
- [ ] Browser console is clean on page load (no `[SSE]` or `FAB clicked!` output)
- [ ] Scan progress UI shows "of 11" consistently throughout the scan
- [ ] Sending `{"port": "bad"}` to `/recall` returns HTTP 400 (not 500)
- [ ] Static file serving still works for `/` and `/images/…`; `/../etc/passwd` returns 403

https://claude.ai/code/session_01NL7SvXedgMikNr3mpZZ45m

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL7SvXedgMikNr3mpZZ45m)_