### PR TITLE
feat: per-preset screenshot capture with PVW/PGM source toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -462,6 +462,14 @@
       margin-top: 16px;
     }
 
+    #capture-source-toggle { display: flex; gap: 4px; }
+    #capture-source-toggle .csrc-btn {
+      padding: 5px 9px; font-size: .75rem; font-weight: 600;
+    }
+    #capture-source-toggle .csrc-btn.active {
+      border-color: var(--accent); color: var(--accent);
+    }
+
     .btn-primary {
       background: var(--accent); border: none; border-radius: 7px;
       color: #fff; padding: 8px 18px; font-size: .85rem; font-weight: 600;
@@ -639,6 +647,11 @@
   <div id="toolbar">
     <button class="btn-primary" id="btn-scan">Scan All Presets</button>
     <button class="btn-ghost"    id="btn-edit">Edit Labels</button>
+    <div id="capture-source-toggle" style="display:none">
+      <button class="btn-ghost csrc-btn" data-src="active"   title="Capture from active camera">ACT</button>
+      <button class="btn-ghost csrc-btn" data-src="preview"  title="Capture from ATEM preview">PVW</button>
+      <button class="btn-ghost csrc-btn" data-src="program"  title="Capture from ATEM program">PGM</button>
+    </div>
     <div id="scan-bar">
       <div id="scan-track"><div id="scan-fill"></div></div>
       <span id="scan-label"></span>
@@ -823,6 +836,7 @@
     atemFollows: 'preview',
     previewSource: null,
     programSource: null,
+    captureSource: 'active',
     presetStart: 0,
     presetEnd: 11,
     gridCols: 4,
@@ -1270,10 +1284,32 @@
   })();
 
   // ── Live/Edit mode toggle ──────────────────────────────────────────────────
+  const elCaptureToggle = document.getElementById('capture-source-toggle');
+
   function updateToolbarVisibility() {
     const btnScanEl = document.getElementById('btn-scan');
     if (btnScanEl) btnScanEl.style.display = state.liveMode ? 'none' : '';
+    if (elCaptureToggle) {
+      elCaptureToggle.style.display =
+        (!state.liveMode && state.atem.enabled) ? 'flex' : 'none';
+    }
   }
+
+  // Restore capture source preference and wire up toggle buttons
+  (function initCaptureToggle() {
+    const saved = localStorage.getItem('captureSource');
+    if (saved) state.captureSource = saved;
+    elCaptureToggle.querySelectorAll('.csrc-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.src === state.captureSource);
+      btn.addEventListener('click', () => {
+        state.captureSource = btn.dataset.src;
+        localStorage.setItem('captureSource', state.captureSource);
+        elCaptureToggle.querySelectorAll('.csrc-btn').forEach(b =>
+          b.classList.toggle('active', b === btn)
+        );
+      });
+    });
+  })();
 
   const elLiveBtn = document.getElementById('live-mode-btn');
   if (elLiveBtn) {
@@ -1693,12 +1729,28 @@
     refreshPresetImage(btn, cam, n);
   }
 
+  function resolveCaptureCamera() {
+    if (state.captureSource === 'preview' && state.atem.enabled) {
+      const idx = state.cameras.findIndex(c => +c.atemInput === +state.previewSource);
+      if (idx >= 0) return idx;
+    }
+    if (state.captureSource === 'program' && state.atem.enabled) {
+      const idx = state.cameras.findIndex(c => +c.atemInput === +state.programSource);
+      if (idx >= 0) return idx;
+    }
+    return state.activeCam;
+  }
+
   async function capturePreset(n) {
-    const cam = state.activeCam;
+    const cam = resolveCaptureCamera();
     const ok = await captureFrame(cam, n);
     if (ok) {
       bumpImageVersion(cam, n);
-      refreshPresetBtn(n, cam);
+      if (cam === state.activeCam) {
+        refreshPresetBtn(n, cam);
+      } else {
+        setStatus('success', `Captured preset ${n} (camera ${cam + 1})`);
+      }
     }
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1233,6 +1233,7 @@
     if (!state.atem.enabled) atemConnected = false;
     updateAtemPill();
     updateAtemDebug();
+    updateToolbarVisibility();
     // Show/hide Live preference field based on ATEM enabled state
     if (elLivePreferenceField) {
       elLivePreferenceField.style.display = state.atem.enabled ? 'block' : 'none';
@@ -1809,6 +1810,7 @@
     captureBtn.type      = 'button';
     captureBtn.title     = 'Update screenshot';
     captureBtn.innerHTML = '&#x25CE;';
+    captureBtn.addEventListener('pointerup', (e) => e.stopPropagation());
     captureBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       await capturePreset(n);

--- a/public/index.html
+++ b/public/index.html
@@ -427,6 +427,19 @@
     .preset-btn.edit-mode.has-image:hover .preset-clear { display: flex; }
     .preset-clear:hover { background: var(--error); border-color: var(--error); }
 
+    .preset-capture {
+      position: absolute; top: 5px; left: 5px;
+      width: 20px; height: 20px;
+      background: rgba(0,0,0,.65); border: 1px solid rgba(255,255,255,.25);
+      border-radius: 50%; color: #fff; font-size: .75rem; line-height: 1;
+      cursor: pointer; display: none;
+      align-items: center; justify-content: center;
+      transition: background .15s;
+      z-index: 2;
+    }
+    .preset-btn.edit-mode:hover .preset-capture { display: flex; }
+    .preset-capture:hover { background: var(--accent); border-color: var(--accent); }
+
     .name-input {
       font-size: .7rem; background: var(--surf2);
       border: 1px solid var(--accent); border-radius: 3px;
@@ -1680,6 +1693,15 @@
     refreshPresetImage(btn, cam, n);
   }
 
+  async function capturePreset(n) {
+    const cam = state.activeCam;
+    const ok = await captureFrame(cam, n);
+    if (ok) {
+      bumpImageVersion(cam, n);
+      refreshPresetBtn(n, cam);
+    }
+  }
+
   function buildPresetBtn(n) {
     const cam = state.activeCam;
     const lbl = state.labels[presetKey(cam, n)] || '';
@@ -1729,6 +1751,17 @@
       refreshPresetBtn(n, activeCam);
     });
     btn.appendChild(clearBtn);
+
+    const captureBtn = document.createElement('button');
+    captureBtn.className = 'preset-capture';
+    captureBtn.type      = 'button';
+    captureBtn.title     = 'Update screenshot';
+    captureBtn.innerHTML = '&#x25CE;';
+    captureBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      await capturePreset(n);
+    });
+    btn.appendChild(captureBtn);
 
     let handledPointerUp = false;
     function activatePreset() {


### PR DESCRIPTION
## Summary

- Adds a **◎ capture icon** to each preset tile (top-left, appears on hover in edit mode) so individual preset thumbnails can be updated without running a full scan
- Adds an **ACT / PVW / PGM toggle** in the edit toolbar (shown only when ATEM is enabled) to select which camera feed to capture from
- **ACT** uses the active camera tab (existing behaviour); **PVW** resolves to whichever camera is currently on ATEM preview; **PGM** resolves to program — both fall back to active camera if no mapping is found
- Toggle selection persists across page reloads via `localStorage`

## Milestones

| Commit | Change |
|---|---|
| `60cc78a` | M1 — per-preset ◎ capture button, wired to active camera |
| `92c7c20` | M2 — PVW/PGM toggle, `resolveCaptureCamera()`, updated `capturePreset()` |

## Test plan

- [ ] Start server: `python server.py`, open http://localhost:5001
- [ ] Switch to Edit mode — ◎ icon appears top-left of each preset tile on hover
- [ ] Click ◎ on any preset → thumbnail captured and updated immediately for that preset
- [ ] × (clear) button still works as before (top-right, only on presets with images)
- [ ] ACT/PVW/PGM toggle not visible when ATEM is disabled in settings
- [ ] Enable ATEM → toggle appears in toolbar; preference survives page reload
- [ ] With ATEM connected: PVW captures from the preview-source camera's feed; PGM from program-source camera's feed
- [ ] Live mode → toolbar (scan, toggle) hidden as before

https://claude.ai/code/session_01VBWWVGhdUhi9jKs8EwQBBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBWWVGhdUhi9jKs8EwQBBu)_