### PR TITLE
Add individual preset button capture feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2160,27 +2160,28 @@
       preset_btn.classList.remove('state-ok', 'state-fail');
     }
 
-    const startTime = Date.now();
-    const ok = await captureFrame(cam, preset);
+    try {
+      const ok = await captureFrame(cam, preset);
 
-    if (ok) {
-      bumpImageVersion(cam, preset);
-      refreshPresetBtn(preset, cam);
-      if (preset_btn) {
-        preset_btn.classList.remove('state-busy');
-        preset_btn.classList.add('state-ok');
-        setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+      if (ok) {
+        bumpImageVersion(cam, preset);
+        refreshPresetBtn(preset, cam);
+        if (preset_btn) {
+          preset_btn.classList.remove('state-busy');
+          preset_btn.classList.add('state-ok');
+          setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+        }
+        setStatus('success', `Captured preset ${preset}`);
+      } else {
+        if (preset_btn) {
+          preset_btn.classList.remove('state-busy');
+          preset_btn.classList.add('state-fail');
+          setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
+        }
       }
-      setStatus('success', `Captured preset ${preset}`);
-    } else {
-      if (preset_btn) {
-        preset_btn.classList.remove('state-busy');
-        preset_btn.classList.add('state-fail');
-        setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
-      }
+    } finally {
+      btn.disabled = false;
     }
-
-    btn.disabled = false;
   }
 
   // ── Preset grid ────────────────────────────────────────────────────────────
@@ -2390,6 +2391,7 @@
     captureBtn.type      = 'button';
     captureBtn.title     = 'Capture snapshot';
     captureBtn.textContent = '⭐';
+    captureBtn.addEventListener('pointerup', (e) => { e.stopPropagation(); });
     captureBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const activeCam = state.activeCam;

--- a/public/index.html
+++ b/public/index.html
@@ -457,6 +457,20 @@
       text-shadow: 0 1px 3px rgba(0,0,0,.9);
     }
 
+    .preset-capture {
+      position: absolute; top: 5px; left: 5px;
+      width: 20px; height: 20px;
+      background: rgba(0,0,0,.65); border: 1px solid rgba(255,255,255,.25);
+      border-radius: 50%; color: #fff; font-size: .75rem; line-height: 1;
+      cursor: pointer; display: none;
+      align-items: center; justify-content: center;
+      transition: background .15s;
+      z-index: 2;
+    }
+    .preset-btn.edit-mode .preset-capture { display: flex; opacity: 0.55; }
+    .preset-btn.edit-mode:hover .preset-capture { opacity: 1; }
+    .preset-capture:hover { background: var(--accent); border-color: var(--accent); }
+
     .preset-clear {
       position: absolute; top: 5px; right: 5px;
       width: 20px; height: 20px;
@@ -2138,6 +2152,37 @@
     return true;
   }
 
+  async function capturePresetImage(cam, preset, btn) {
+    btn.disabled = true;
+    const preset_btn = btn.closest('.preset-btn');
+    if (preset_btn) {
+      preset_btn.classList.add('state-busy');
+      preset_btn.classList.remove('state-ok', 'state-fail');
+    }
+
+    const startTime = Date.now();
+    const ok = await captureFrame(cam, preset);
+
+    if (ok) {
+      bumpImageVersion(cam, preset);
+      refreshPresetBtn(preset, cam);
+      if (preset_btn) {
+        preset_btn.classList.remove('state-busy');
+        preset_btn.classList.add('state-ok');
+        setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+      }
+      setStatus('success', `Captured preset ${preset}`);
+    } else {
+      if (preset_btn) {
+        preset_btn.classList.remove('state-busy');
+        preset_btn.classList.add('state-fail');
+        setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
+      }
+    }
+
+    btn.disabled = false;
+  }
+
   // ── Preset grid ────────────────────────────────────────────────────────────
   const elGrid = document.getElementById('preset-grid');
   let editMode = false;
@@ -2339,6 +2384,18 @@
     ov.appendChild(ovNum);
     ov.appendChild(ovName);
     btn.appendChild(ov);
+
+    const captureBtn = document.createElement('button');
+    captureBtn.className = 'preset-capture';
+    captureBtn.type      = 'button';
+    captureBtn.title     = 'Capture snapshot';
+    captureBtn.textContent = '⭐';
+    captureBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const activeCam = state.activeCam;
+      await capturePresetImage(activeCam, n, captureBtn);
+    });
+    btn.appendChild(captureBtn);
 
     const clearBtn = document.createElement('button');
     clearBtn.className   = 'preset-clear';


### PR DESCRIPTION
## Summary
Adds the ability to capture images for individual preset buttons directly from the connected camera, without running a full auto-scan of all presets.

- New capture button (⭐) appears on each preset in edit mode
- Clicking captures from the configured source: USB device → stream URL → browser webcam fallback
- Visual feedback during capture: busy state, success/error indicators
- Reuses existing `captureFrame()` logic for source priority

## How to Use
1. Enable edit mode
2. Click the ⭐ button on any preset to capture an image for that preset
3. The button shows:
   - Busy state (blue border) while capturing
   - Success state (green border) for 1s on successful capture
   - Error state (red border) for 1.5s on capture failure

---
_Generated by [Claude Code](https://claude.ai/code/session_01Em4KmTsfeepGr5HHfhbM1N)_