### PR TITLE
Add auto-lock safety feature for live mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2160,27 +2160,28 @@
       preset_btn.classList.remove('state-ok', 'state-fail');
     }
 
-    const startTime = Date.now();
-    const ok = await captureFrame(cam, preset);
+    try {
+      const ok = await captureFrame(cam, preset);
 
-    if (ok) {
-      bumpImageVersion(cam, preset);
-      refreshPresetBtn(preset, cam);
-      if (preset_btn) {
-        preset_btn.classList.remove('state-busy');
-        preset_btn.classList.add('state-ok');
-        setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+      if (ok) {
+        bumpImageVersion(cam, preset);
+        refreshPresetBtn(preset, cam);
+        if (preset_btn) {
+          preset_btn.classList.remove('state-busy');
+          preset_btn.classList.add('state-ok');
+          setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+        }
+        setStatus('success', `Captured preset ${preset}`);
+      } else {
+        if (preset_btn) {
+          preset_btn.classList.remove('state-busy');
+          preset_btn.classList.add('state-fail');
+          setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
+        }
       }
-      setStatus('success', `Captured preset ${preset}`);
-    } else {
-      if (preset_btn) {
-        preset_btn.classList.remove('state-busy');
-        preset_btn.classList.add('state-fail');
-        setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
-      }
+    } finally {
+      btn.disabled = false;
     }
-
-    btn.disabled = false;
   }
 
   // ── Preset grid ────────────────────────────────────────────────────────────
@@ -2390,6 +2391,7 @@
     captureBtn.type      = 'button';
     captureBtn.title     = 'Capture snapshot';
     captureBtn.textContent = '⭐';
+    captureBtn.addEventListener('pointerup', (e) => { e.stopPropagation(); });
     captureBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const activeCam = state.activeCam;

--- a/public/index.html
+++ b/public/index.html
@@ -213,6 +213,24 @@
     }
     #live-mode-btn.live:hover { background: var(--success); opacity: 0.9; }
 
+    #lock-live-btn {
+      background: var(--surf2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 5px 10px;
+      color: var(--muted);
+      font-size: 1rem;
+      line-height: 1;
+      cursor: pointer;
+      transition: border-color 0.2s, color 0.2s, background-color 0.2s;
+    }
+    #lock-live-btn:hover { border-color: var(--accent); color: var(--accent); }
+    #lock-live-btn.locked {
+      color: var(--error);
+      border-color: var(--error);
+    }
+    #lock-live-btn.locked:hover { background: rgba(239, 68, 68, 0.1); }
+
     .atem-dot {
       width: 7px; height: 7px; border-radius: 50%;
       background: var(--muted); flex-shrink: 0;
@@ -560,6 +578,7 @@
     body.fill-mode #fill-cam-strip { display: inline-flex; }
     body.fill-mode #fullscreen-btn { padding: 4px 8px; font-size: 0.92rem; }
     body.fill-mode #live-mode-btn { padding: 4px 9px; font-size: 0.68rem; }
+    body.fill-mode #lock-live-btn { padding: 4px 8px; font-size: 0.92rem; }
     body.fill-mode #atem-pill { padding: 4px 8px; font-size: 0.68rem; }
     body.fill-mode #status { min-width: 112px; padding: 3px 8px; font-size: 0.7rem; }
     body.fill-mode #cam-tabs { display: none; }
@@ -781,6 +800,7 @@
     <div id="fill-cam-strip" aria-label="Camera status controls"></div>
     <button id="fullscreen-btn" title="Toggle fullscreen">&#x26F6;</button>
     <button id="live-mode-btn" class="live" title="Toggle Live/Edit mode">Live</button>
+    <button id="lock-live-btn" title="Prevent camera movement in live mode">🔓</button>
     <div id="atem-pill" class="disabled">
       <div class="atem-dot"></div>
       <span>ATEM</span>
@@ -1022,6 +1042,7 @@
     atem: { ip: '', enabled: false },
     showAtemDebug: false,
     liveMode: true,
+    lockLiveMode: false,
     atemFollows: 'preview',
     previewSource: null,
     programSource: null,
@@ -1125,6 +1146,7 @@
         if (s.gridRows    != null) state.gridRows    = +s.gridRows;
         if (s.fillWindow  != null) state.fillWindow  = !!s.fillWindow;
         if (s.liveMode      != null) state.liveMode      = !!s.liveMode;
+        if (s.lockLiveMode  != null) state.lockLiveMode  = !!s.lockLiveMode;
         if (s.showAtemDebug != null) state.showAtemDebug = !!s.showAtemDebug;
         if (s.atemFollows)           state.atemFollows   = s.atemFollows;
         if (s.atemOutputMap) state.atemOutputMap = normalizeAtemOutputMap(s.atemOutputMap);
@@ -1691,6 +1713,20 @@
       schedSave();
       renderTabs();
       updateToolbarVisibility();
+    });
+  }
+
+  const elLockLiveBtn = document.getElementById('lock-live-btn');
+  if (elLockLiveBtn) {
+    function updateLockIcon() {
+      elLockLiveBtn.textContent = state.lockLiveMode ? '🔒' : '🔓';
+      elLockLiveBtn.classList.toggle('locked', state.lockLiveMode);
+    }
+    updateLockIcon();
+    elLockLiveBtn.addEventListener('click', () => {
+      state.lockLiveMode = !state.lockLiveMode;
+      updateLockIcon();
+      schedSave();
     });
   }
 
@@ -2500,6 +2536,10 @@
   }
 
   async function recallPreset(n, btn) {
+    if (state.liveMode && state.lockLiveMode) {
+      setStatus('error', 'Cannot recall presets while live mode is locked');
+      flash(btn, 'fail'); return;
+    }
     const cam = state.cameras[state.activeCam];
     if (!cam.ip) {
       setStatus('error', 'Enter the camera IP address first');

--- a/public/index.html
+++ b/public/index.html
@@ -219,17 +219,22 @@
       border-radius: 6px;
       padding: 5px 10px;
       color: var(--muted);
-      font-size: 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
       line-height: 1;
       cursor: pointer;
       transition: border-color 0.2s, color 0.2s, background-color 0.2s;
+      min-width: 78px;
+      text-align: center;
     }
     #lock-live-btn:hover { border-color: var(--accent); color: var(--accent); }
     #lock-live-btn.locked {
-      color: var(--error);
+      color: white;
+      background: var(--error);
       border-color: var(--error);
+      font-weight: 600;
     }
-    #lock-live-btn.locked:hover { background: rgba(239, 68, 68, 0.1); }
+    #lock-live-btn.locked:hover { opacity: 0.9; }
 
     .atem-dot {
       width: 7px; height: 7px; border-radius: 50%;
@@ -578,7 +583,7 @@
     body.fill-mode #fill-cam-strip { display: inline-flex; }
     body.fill-mode #fullscreen-btn { padding: 4px 8px; font-size: 0.92rem; }
     body.fill-mode #live-mode-btn { padding: 4px 9px; font-size: 0.68rem; }
-    body.fill-mode #lock-live-btn { padding: 4px 8px; font-size: 0.92rem; }
+    body.fill-mode #lock-live-btn { padding: 4px 8px; font-size: 0.65rem; min-width: 70px; }
     body.fill-mode #atem-pill { padding: 4px 8px; font-size: 0.68rem; }
     body.fill-mode #status { min-width: 112px; padding: 3px 8px; font-size: 0.7rem; }
     body.fill-mode #cam-tabs { display: none; }
@@ -800,7 +805,7 @@
     <div id="fill-cam-strip" aria-label="Camera status controls"></div>
     <button id="fullscreen-btn" title="Toggle fullscreen">&#x26F6;</button>
     <button id="live-mode-btn" class="live" title="Toggle Live/Edit mode">Live</button>
-    <button id="lock-live-btn" title="Prevent camera movement in live mode">🔓</button>
+    <button id="lock-live-btn" title="Lock camera to prevent preset movement"></button>
     <div id="atem-pill" class="disabled">
       <div class="atem-dot"></div>
       <span>ATEM</span>
@@ -1043,6 +1048,7 @@
     showAtemDebug: false,
     liveMode: true,
     lockLiveMode: false,
+    unlockOnExitLiveMode: true,
     atemFollows: 'preview',
     previewSource: null,
     programSource: null,
@@ -1147,6 +1153,7 @@
         if (s.fillWindow  != null) state.fillWindow  = !!s.fillWindow;
         if (s.liveMode      != null) state.liveMode      = !!s.liveMode;
         if (s.lockLiveMode  != null) state.lockLiveMode  = !!s.lockLiveMode;
+        if (s.unlockOnExitLiveMode != null) state.unlockOnExitLiveMode = !!s.unlockOnExitLiveMode;
         if (s.showAtemDebug != null) state.showAtemDebug = !!s.showAtemDebug;
         if (s.atemFollows)           state.atemFollows   = s.atemFollows;
         if (s.atemOutputMap) state.atemOutputMap = normalizeAtemOutputMap(s.atemOutputMap);
@@ -1708,8 +1715,17 @@
   if (elLiveBtn) {
     elLiveBtn.addEventListener('click', () => {
       state.liveMode = !state.liveMode;
+      if (state.liveMode) {
+        state.lockLiveMode = true;
+        setStatus('success', 'Live mode activated - camera locked to prevent accidental movement');
+      } else {
+        if (state.unlockOnExitLiveMode) {
+          state.lockLiveMode = false;
+        }
+      }
       elLiveBtn.textContent = state.liveMode ? 'Live' : 'Edit';
       elLiveBtn.classList.toggle('live', state.liveMode);
+      if (elLockLiveBtn) updateLockIcon();
       schedSave();
       renderTabs();
       updateToolbarVisibility();
@@ -1719,8 +1735,13 @@
   const elLockLiveBtn = document.getElementById('lock-live-btn');
   if (elLockLiveBtn) {
     function updateLockIcon() {
-      elLockLiveBtn.textContent = state.lockLiveMode ? '🔒' : '🔓';
-      elLockLiveBtn.classList.toggle('locked', state.lockLiveMode);
+      if (state.lockLiveMode) {
+        elLockLiveBtn.textContent = '🔒 Locked';
+        elLockLiveBtn.classList.add('locked');
+      } else {
+        elLockLiveBtn.textContent = '🔓 Unlock';
+        elLockLiveBtn.classList.remove('locked');
+      }
     }
     updateLockIcon();
     elLockLiveBtn.addEventListener('click', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -457,6 +457,20 @@
       text-shadow: 0 1px 3px rgba(0,0,0,.9);
     }
 
+    .preset-capture {
+      position: absolute; top: 5px; left: 5px;
+      width: 20px; height: 20px;
+      background: rgba(0,0,0,.65); border: 1px solid rgba(255,255,255,.25);
+      border-radius: 50%; color: #fff; font-size: .75rem; line-height: 1;
+      cursor: pointer; display: none;
+      align-items: center; justify-content: center;
+      transition: background .15s;
+      z-index: 2;
+    }
+    .preset-btn.edit-mode .preset-capture { display: flex; opacity: 0.55; }
+    .preset-btn.edit-mode:hover .preset-capture { opacity: 1; }
+    .preset-capture:hover { background: var(--accent); border-color: var(--accent); }
+
     .preset-clear {
       position: absolute; top: 5px; right: 5px;
       width: 20px; height: 20px;
@@ -2138,6 +2152,37 @@
     return true;
   }
 
+  async function capturePresetImage(cam, preset, btn) {
+    btn.disabled = true;
+    const preset_btn = btn.closest('.preset-btn');
+    if (preset_btn) {
+      preset_btn.classList.add('state-busy');
+      preset_btn.classList.remove('state-ok', 'state-fail');
+    }
+
+    const startTime = Date.now();
+    const ok = await captureFrame(cam, preset);
+
+    if (ok) {
+      bumpImageVersion(cam, preset);
+      refreshPresetBtn(preset, cam);
+      if (preset_btn) {
+        preset_btn.classList.remove('state-busy');
+        preset_btn.classList.add('state-ok');
+        setTimeout(() => preset_btn.classList.remove('state-ok'), 1000);
+      }
+      setStatus('success', `Captured preset ${preset}`);
+    } else {
+      if (preset_btn) {
+        preset_btn.classList.remove('state-busy');
+        preset_btn.classList.add('state-fail');
+        setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
+      }
+    }
+
+    btn.disabled = false;
+  }
+
   // ── Preset grid ────────────────────────────────────────────────────────────
   const elGrid = document.getElementById('preset-grid');
   let editMode = false;
@@ -2339,6 +2384,18 @@
     ov.appendChild(ovNum);
     ov.appendChild(ovName);
     btn.appendChild(ov);
+
+    const captureBtn = document.createElement('button');
+    captureBtn.className = 'preset-capture';
+    captureBtn.type      = 'button';
+    captureBtn.title     = 'Capture snapshot';
+    captureBtn.textContent = '⭐';
+    captureBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const activeCam = state.activeCam;
+      await capturePresetImage(activeCam, n, captureBtn);
+    });
+    btn.appendChild(captureBtn);
 
     const clearBtn = document.createElement('button');
     clearBtn.className   = 'preset-clear';

--- a/server.py
+++ b/server.py
@@ -78,6 +78,7 @@ DEFAULT_SETTINGS = {
     "dwellMs": 3000,
     "atem": {"ip": "", "enabled": False},
     "liveMode": True,
+    "lockLiveMode": False,
     "atemFollows": "preview",
     "atemOutputMap": {
         "webcam": {"webcam": "", "streamUrl": ""},

--- a/server.py
+++ b/server.py
@@ -79,6 +79,7 @@ DEFAULT_SETTINGS = {
     "atem": {"ip": "", "enabled": False},
     "liveMode": True,
     "lockLiveMode": False,
+    "unlockOnExitLiveMode": True,
     "atemFollows": "preview",
     "atemOutputMap": {
         "webcam": {"webcam": "", "streamUrl": ""},


### PR DESCRIPTION
## Summary
Implements auto-lock safety feature to prevent accidental preset recalls while in Live mode. When entering Live mode, the camera automatically locks to prevent accidental movement. Unlock behavior is configurable.

### Changes
- **Auto-Lock in Live Mode**: Camera locks automatically when switching to Live mode
- **Configurable Exit Behavior**: New setting `unlockOnExitLiveMode` (default: true) controls whether lock releases when exiting Live mode
- **Improved Lock Button**: Shows text labels (🔓 Unlock / 🔒 Locked) with red background when locked
- **Visual Feedback**: Toast notification when entering Live mode with lock activation
- **Settings Persistence**: All settings persist across browser sessions

### Protection
- Attempting to recall a preset while locked shows error: "Cannot recall presets while live mode is locked"
- User must explicitly unlock button to move camera in Live mode
- Configurable safety level based on preference

### Testing
- All syntax checks pass (Python, JS, HTML)
- Lock button visible and functional
- Auto-lock triggers on Live mode entry
- Settings load and persist correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Em4KmTsfeepGr5HHfhbM1N)_