### PR TITLE
Fix auto-lock and improve lock to protect only LIVE camera

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1742,6 +1742,27 @@
     if (btnScanEl) btnScanEl.style.display = state.liveMode ? 'none' : '';
   }
 
+  // Define lock button handler FIRST so it's available for live button to use
+  let updateLockIcon;
+  const elLockLiveBtn = document.getElementById('lock-live-btn');
+  if (elLockLiveBtn) {
+    updateLockIcon = function() {
+      if (state.lockLiveMode) {
+        elLockLiveBtn.textContent = '🔒 Locked';
+        elLockLiveBtn.classList.add('locked');
+      } else {
+        elLockLiveBtn.textContent = '🔓 Unlock';
+        elLockLiveBtn.classList.remove('locked');
+      }
+    };
+    updateLockIcon();
+    elLockLiveBtn.addEventListener('click', () => {
+      state.lockLiveMode = !state.lockLiveMode;
+      updateLockIcon();
+      schedSave();
+    });
+  }
+
   const elLiveBtn = document.getElementById('live-mode-btn');
   if (elLiveBtn) {
     elLiveBtn.addEventListener('click', () => {
@@ -1756,29 +1777,10 @@
       }
       elLiveBtn.textContent = state.liveMode ? 'Live' : 'Edit';
       elLiveBtn.classList.toggle('live', state.liveMode);
-      if (elLockLiveBtn) updateLockIcon();
+      if (updateLockIcon) updateLockIcon();
       schedSave();
       renderTabs();
       updateToolbarVisibility();
-    });
-  }
-
-  const elLockLiveBtn = document.getElementById('lock-live-btn');
-  if (elLockLiveBtn) {
-    function updateLockIcon() {
-      if (state.lockLiveMode) {
-        elLockLiveBtn.textContent = '🔒 Locked';
-        elLockLiveBtn.classList.add('locked');
-      } else {
-        elLockLiveBtn.textContent = '🔓 Unlock';
-        elLockLiveBtn.classList.remove('locked');
-      }
-    }
-    updateLockIcon();
-    elLockLiveBtn.addEventListener('click', () => {
-      state.lockLiveMode = !state.lockLiveMode;
-      updateLockIcon();
-      schedSave();
     });
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2591,8 +2591,12 @@
 
   async function recallPreset(n, btn) {
     if (state.liveMode && state.lockLiveMode) {
-      setStatus('error', 'Cannot recall presets while live mode is locked');
-      flash(btn, 'fail'); return;
+      const activeCam = state.activeCam;
+      const isLiveCamera = cameraMatchesAtemSource(activeCam, state.programSource);
+      if (isLiveCamera) {
+        setStatus('error', 'Cannot move LIVE camera while lock is enabled');
+        flash(btn, 'fail'); return;
+      }
     }
     const cam = state.cameras[state.activeCam];
     if (!cam.ip) {


### PR DESCRIPTION
## Summary
Fixes the auto-lock bug AND improves lock behavior to be more granular - protecting only the LIVE camera while allowing other cameras to be moved.

## Bug Fix: Auto-Lock Not Engaging
- **Issue**: Lock button didn't show as locked when entering Live mode
- **Cause**: `updateLockIcon()` was being called before it was defined
- **Fix**: Reordered code so lock handler initializes first

## Improvement: Protect Only LIVE Camera
- **Old behavior**: Lock prevented ALL camera recalls in Live mode
- **New behavior**: Lock protects only the camera on PROGRAM (broadcasting), allows other recalls
- **Benefit**: Operators can adjust preview/unmapped cameras while protecting the live broadcast camera

### Example
When in Live mode with lock enabled:
- **Camera 1 (LIVE on PROGRAM)**: Recall blocked ✓
- **Camera 2 (PREVIEW)**: Recall allowed ✓  
- **Camera 3 (UNMAPPED)**: Recall allowed ✓

Error message: "Cannot move LIVE camera while lock is enabled"

## Testing Checklist
- ✅ Auto-lock visually engages when entering Live mode
- ✅ Lock prevents recalls of LIVE camera only
- ✅ Lock allows recalls of non-LIVE cameras
- ✅ All syntax checks pass