### PR TITLE
beta/v1.0: DEV + long-press ATEM preview + auto-cut redo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,15 @@ Frontend event types:
 
 In Live mode, the UI can follow either preview or program via `atemFollows`.
 
+ATEM status must reflect the switcher state observed from ATEM polling and inbound updates, not optimistic assumptions based on app actions. Outside actors can change preview/program selection or cut between cameras at any time, so the UI should treat app-issued commands as requests and ATEM-reported state as the source of truth.
+
+### Action ordering
+
+Explore serializing ATEM actions and camera recalls through a queue or equivalent coordinator when workflows become more concurrent.
+
+- Queueing may help prevent overlapping recall, preview-select, and cut requests from producing misleading UI state.
+- Any queue design should preserve live-safety guardrails, surface pending/running/failed state clearly, and still reconcile final state against what ATEM and the cameras actually report.
+
 ### Capture priority
 
 Preset image capture uses this order:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,15 @@ Frontend event types:
 
 In Live mode, the UI can follow either preview or program via `atemFollows`.
 
+ATEM status must reflect the switcher state observed from ATEM polling and inbound updates, not optimistic assumptions based on app actions. Outside actors can change preview/program selection or cut between cameras at any time, so the UI should treat app-issued commands as requests and ATEM-reported state as the source of truth.
+
+### Action ordering
+
+Explore serializing ATEM actions and camera recalls through a queue or equivalent coordinator when workflows become more concurrent.
+
+- Queueing may help prevent overlapping recall, preview-select, and cut requests from producing misleading UI state.
+- Any queue design should preserve live-safety guardrails, surface pending/running/failed state clearly, and still reconcile final state against what ATEM and the cameras actually report.
+
 ### Capture priority
 
 Preset image capture uses this order:

--- a/public/index.html
+++ b/public/index.html
@@ -1211,6 +1211,11 @@
     #toolbar > * + *        { margin-left: 0; }
     #toolbar-right > * + *  { margin-left: 0; }
     #toolbar-statuses > * + * { margin-left: 0; }
+    @supports not (gap: 1px) {
+      #toolbar > * + *          { margin-left: 10px; }
+      #toolbar-right > * + *    { margin-left: 10px; }
+      #toolbar-statuses > * + * { margin-left: 8px; }
+    }
     #scan-bar > * + *       { margin-left: 12px; }
     .field > * + *          { margin-top: 4px; }
     #webcam-preview > * + * { margin-top: 4px; }

--- a/public/index.html
+++ b/public/index.html
@@ -156,14 +156,7 @@
       color: var(--muted);
     }
 
-    @keyframes pvw-set-flash {
-      0%   { box-shadow: 0 0 0 0 rgba(34,197,94,.8); border-color: var(--success); }
-      60%  { box-shadow: 0 0 0 6px rgba(34,197,94,0); border-color: var(--success); }
-      100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
-    }
-    .fill-cam-indicator.setting-preview {
-      animation: pvw-set-flash 0.8s ease-out;
-    }
+
 
     #status {
       display: flex; align-items: center;

--- a/public/index.html
+++ b/public/index.html
@@ -1974,15 +1974,16 @@
   }
 
   async function setAtemPreview(idx) {
-    if (!state.atem.enabled || !atemConnected) return;
+    if (!state.atem.enabled || !atemConnected) return false;
     const atemInput = getCameraAtemInput(idx);
-    if (!atemInput) return;
-    if (cameraMatchesAtemSource(idx, state.previewSource)) return;
-    await fetch('/api/atem/preview', {
+    if (!atemInput) return false;
+    if (cameraMatchesAtemSource(idx, state.previewSource)) return false;
+    fetch('/api/atem/preview', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ camIdx: idx }),
     }).catch(() => ({}));
+    return true;
   }
 
   function renderFillCamStrip() {
@@ -2013,12 +2014,13 @@
       let lpTimer = null;
       let lpHandled = false;
       btn.addEventListener('pointerdown', () => {
-        lpTimer = setTimeout(() => {
+        lpTimer = setTimeout(async () => {
           lpTimer = null;
           lpHandled = true;
-          btn.classList.add('setting-preview');
-          setTimeout(() => btn.classList.remove('setting-preview'), 800);
-          setAtemPreview(idx);
+          if (await setAtemPreview(idx)) {
+            btn.classList.add('setting-preview');
+            setTimeout(() => btn.classList.remove('setting-preview'), 800);
+          }
         }, 500);
       });
       const clearFillLongPress = () => { clearTimeout(lpTimer); lpTimer = null; };
@@ -2074,11 +2076,14 @@
       //   700 ms → rename tab (always available; +200 ms after preview)
       let longPressTimer = null;
       let longPressHandled = false;
+      let previewHoldTriggered = false;
       btn.addEventListener('pointerdown', () => {
+        previewHoldTriggered = false;
         longPressTimer = setTimeout(() => {
           longPressHandled = true;
           if (state.atem.enabled && atemConnected) {
-            setAtemPreview(idx);
+            previewHoldTriggered = true;
+            void setAtemPreview(idx);
             // Schedule rename after an additional 200 ms (700 ms total)
             longPressTimer = setTimeout(() => {
               longPressTimer = null;
@@ -2092,11 +2097,11 @@
       });
       btn.addEventListener('pointerup', () => {
         if (longPressTimer !== null) {
-          // In the 500–700 ms window: rename was pending, cancel it and
-          // reset longPressHandled so the click event can still fire normally.
+          // In the 500–700 ms window: rename was pending, cancel it.
+          // Only restore normal click if preview was never triggered.
           clearTimeout(longPressTimer);
           longPressTimer = null;
-          longPressHandled = false;
+          if (!previewHoldTriggered) longPressHandled = false;
         } else {
           clearTimeout(longPressTimer);
           longPressTimer = null;
@@ -3281,11 +3286,12 @@
     const toolbarStyles = getComputedStyle(elToolbar);
     const toolbarMarginTop = parseFloat(toolbarStyles.marginTop || '0') || 0;
     const stagePadX = (parseFloat(stageStyles.paddingLeft || '0') || 0) + (parseFloat(stageStyles.paddingRight || '0') || 0);
+    const stagePadY = (parseFloat(stageStyles.paddingTop || '0') || 0) + (parseFloat(stageStyles.paddingBottom || '0') || 0);
 
     const availableWidth = Math.max(0, elPresetStage.clientWidth - stagePadX);
     const availableHeight = Math.max(
       0,
-      elMain.clientHeight - elToolbar.offsetHeight - toolbarMarginTop
+      elMain.clientHeight - elToolbar.offsetHeight - toolbarMarginTop - stagePadY
     );
 
     function fitLayout(cols, rows) {

--- a/public/index.html
+++ b/public/index.html
@@ -43,14 +43,6 @@
       flex-shrink: 0;
     }
 
-    .brand-icon {
-      width: 28px; height: 28px;
-      background: var(--accent);
-      border-radius: 6px;
-      display: flex; align-items: center; justify-content: center;
-      flex-shrink: 0;
-    }
-    .brand-icon svg { width: 15px; height: 15px; fill: #fff; }
     .brand-text h1  { font-size: 0.9rem; font-weight: 600; color: #fff; }
     .brand-text p   { font-size: 0.65rem; color: var(--muted); margin-top: 1px; }
 
@@ -214,12 +206,17 @@
       background: var(--surf2);
       border: 1px solid var(--border);
       border-radius: 6px;
-      padding: 5px 10px;
+      padding: 7px 12px;
+      min-height: 46px;
       color: var(--muted);
       font-size: 1rem;
       line-height: 1;
       cursor: pointer;
       transition: border-color 0.2s, color 0.2s;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
     }
     #fullscreen-btn:hover { border-color: var(--accent); color: var(--accent); }
 
@@ -227,15 +224,21 @@
       background: var(--surf2);
       border: 1px solid var(--border);
       border-radius: 6px;
-      padding: 6px 12px;
+      padding: 8px 14px;
+      min-height: 46px;
       color: var(--muted);
       font-size: 0.75rem;
       font-weight: 600;
+      line-height: 1;
       text-transform: uppercase;
       letter-spacing: 0.5px;
       cursor: pointer;
       transition: border-color 0.2s, color 0.2s, background-color 0.2s;
       user-select: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
     }
     #live-mode-btn:hover { border-color: var(--accent); color: var(--accent); }
     #live-mode-btn.live {
@@ -249,15 +252,21 @@
       background: rgba(239, 68, 68, 0.12);
       border: 1px solid rgba(239, 68, 68, 0.35);
       border-radius: 999px;
-      padding: 6px 12px;
+      padding: 8px 14px;
+      min-height: 46px;
       color: #fca5a5;
       font-size: 0.75rem;
       font-weight: 700;
+      line-height: 1;
       text-transform: uppercase;
       letter-spacing: 0.5px;
       cursor: pointer;
       transition: border-color 0.2s, color 0.2s, background-color 0.2s, opacity 0.2s;
       user-select: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
     }
     #cut-live-btn:hover {
       border-color: #f87171;
@@ -269,21 +278,40 @@
       cursor: not-allowed;
     }
 
+    #btn-auto-cut {
+      padding: 8px 14px;
+      min-height: 46px;
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+    }
     #lock-live-btn {
       background: #d97706;
       border: 1px solid #d97706;
       border-radius: 6px;
-      padding: 5px 10px;
+      padding: 7px 8px;
+      min-height: 46px;
       color: white;
       font-size: 0.75rem;
       font-weight: 600;
       line-height: 1;
       cursor: pointer;
       transition: border-color 0.2s, color 0.2s, background-color 0.2s, box-shadow 0.3s;
-      min-width: 78px;
+      min-width: 86px;
       text-align: center;
       box-shadow: 0 0 0 0 rgba(217, 119, 6, 0.7);
       animation: unlock-pulse 2s infinite;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
     }
     @keyframes unlock-pulse {
       0%, 100% { box-shadow: 0 0 0 0 rgba(217, 119, 6, 0.7); }
@@ -322,24 +350,49 @@
     #cam-tabs::-webkit-scrollbar { display: none; }
 
     .cam-tab {
-      background: transparent;
-      border: none;
-      border-bottom: 2px solid transparent;
-      padding: 9px 12px 7px;
+      background: rgba(15, 23, 42, 0.18);
+      border: 2px solid rgba(148, 163, 184, 0.38);
+      border-radius: 12px;
+      padding: 12px 10px 10px;
+      min-height: 46px;
       color: var(--muted);
       font-size: 0.84rem;
       cursor: pointer;
-      transition: color 0.2s, border-color 0.2s;
+      transition: color 0.2s, border-color 0.2s, background-color 0.2s, transform 0.15s;
       user-select: none;
       display: flex; align-items: center;
       flex: 0 0 auto;
       white-space: nowrap;
     }
     .cam-tab:hover { color: var(--text); }
-    .cam-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
-    .cam-tab.live { background: rgba(34, 197, 94, 0.1); }
+    .cam-tab.active {
+      color: var(--accent);
+      font-weight: 600;
+      box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.2);
+    }
+    .cam-tab.active.bus-selected {
+      border-color: rgba(59, 130, 246, 0.68);
+      background: rgba(30, 64, 175, 0.14);
+    }
+    .cam-tab.bus-live { border-color: rgba(239, 68, 68, 0.78); background: rgba(127, 29, 29, 0.14); }
+    .cam-tab.bus-preview { border-color: rgba(34, 197, 94, 0.78); background: rgba(20, 83, 45, 0.14); }
+    .cam-tab.bus-idle { border-color: rgba(148, 163, 184, 0.45); background: rgba(15, 23, 42, 0.18); }
+    .cam-tab.bus-selected { border-color: rgba(59, 130, 246, 0.68); background: rgba(30, 64, 175, 0.14); }
+    .cam-tab.live { background: rgba(239, 68, 68, 0.08); }
+    .cam-tab.preview { background: rgba(34, 197, 94, 0.08); }
     .cam-tab.edit { background: rgba(217, 119, 6, 0.08); }
-
+    .cam-state-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      flex: 0 0 9px;
+      background: rgba(148, 163, 184, 0.55);
+      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
+    }
+    .cam-state-dot.live { background: var(--error); }
+    .cam-state-dot.preview { background: var(--success); }
+    .cam-state-dot.selected { background: var(--accent); }
+    .cam-state-dot.idle { background: rgba(148, 163, 184, 0.55); }
     .cam-badge {
       display: inline-block;
       font-size: 0.55rem;
@@ -376,6 +429,31 @@
       background: var(--surf2); border: 1px solid var(--accent);
       border-radius: 4px; color: var(--text);
       padding: 1px 6px; outline: none; width: 110px;
+    }
+
+    body.header-compact #fullscreen-btn {
+      padding: 5px 10px;
+      min-height: 40px;
+    }
+    body.header-compact #live-mode-btn {
+      padding: 6px 12px;
+      min-height: 40px;
+    }
+    body.header-compact #cut-live-btn {
+      padding: 6px 12px;
+      min-height: 40px;
+    }
+    body.header-compact #btn-auto-cut {
+      padding: 6px 12px;
+      min-height: 40px;
+    }
+    body.header-compact #lock-live-btn {
+      padding: 5px 8px;
+      min-height: 40px;
+    }
+    body.header-compact .cam-tab {
+      padding: 9px 10px 7px;
+      min-height: 40px;
     }
 
     /* ── Settings bar ────────────────────────────────── */
@@ -479,13 +557,40 @@
     /* ── Main ────────────────────────────────────────── */
     main {
       flex: 1;
-      padding: 20px;
+      padding: 10px 20px 20px;
       max-width: 860px;
       width: 100%;
       margin: 0 auto;
     }
 
     /* ── Preset grid ─────────────────────────────────── */
+    #preset-stage {
+      padding: 12px;
+      border: 2px solid rgba(148, 163, 184, 0.45);
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.22);
+      transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+    }
+    #preset-stage.bus-live {
+      border-color: rgba(239, 68, 68, 0.78);
+      box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.28);
+      background: rgba(127, 29, 29, 0.14);
+    }
+    #preset-stage.bus-preview {
+      border-color: rgba(34, 197, 94, 0.78);
+      box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.22);
+      background: rgba(20, 83, 45, 0.14);
+    }
+    #preset-stage.bus-selected {
+      border-color: rgba(59, 130, 246, 0.78);
+      box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.22);
+      background: rgba(30, 64, 175, 0.14);
+    }
+    #preset-stage.bus-idle {
+      border-color: rgba(148, 163, 184, 0.45);
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+      background: rgba(15, 23, 42, 0.22);
+    }
     #preset-grid {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
@@ -610,15 +715,16 @@
       align-items: center;
       flex-wrap: wrap;
       margin-top: 16px;
+      gap: 10px;
     }
 
     #toolbar-right {
-      margin-left: auto;
       display: flex;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: space-between;
       gap: 10px;
-      flex: 1 1 420px;
+      flex: 1 1 100%;
+      width: 100%;
       min-width: 0;
       flex-wrap: wrap;
     }
@@ -628,6 +734,7 @@
       align-items: center;
       justify-content: flex-end;
       gap: 8px;
+      flex: 0 0 auto;
       min-width: 0;
       flex-wrap: wrap;
     }
@@ -639,28 +746,6 @@
     #capture-source-toggle .csrc-btn.active {
       border-color: var(--accent); color: var(--accent);
     }
-    #toolbar-auto-cut-toggle {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 10px;
-      border: 1px solid var(--border);
-      border-radius: 7px;
-      background: var(--surf2);
-      color: var(--muted);
-      font-size: .78rem;
-      font-weight: 600;
-      user-select: none;
-    }
-    #toolbar-auto-cut-toggle input {
-      margin: 0;
-    }
-    #toolbar-auto-cut-toggle.enabled {
-      border-color: var(--success);
-      color: var(--success);
-      background: rgba(16, 185, 129, 0.08);
-    }
-
     .btn-primary {
       background: var(--accent); border: none; border-radius: 7px;
       color: #fff; padding: 8px 18px; font-size: .85rem; font-weight: 600;
@@ -760,18 +845,20 @@
     body.fill-mode .brand-text { display: none; }
     body.fill-mode #fill-cam-strip { display: none; }
     body.fill-mode #fullscreen-btn { padding: 4px 8px; font-size: 0.92rem; }
-    body.fill-mode #live-mode-btn { padding: 4px 9px; font-size: 0.68rem; }
-    body.fill-mode #lock-live-btn { padding: 4px 8px; font-size: 0.65rem; min-width: 70px; }
+    body.fill-mode #live-mode-btn { padding: 4px 9px; font-size: 0.68rem; min-height: 40px; }
+    body.fill-mode #cut-live-btn { min-height: 40px; }
+    body.fill-mode #btn-auto-cut { min-height: 40px; font-size: 0.68rem; padding: 4px 9px; }
+    body.fill-mode #lock-live-btn { padding: 4px 7px; font-size: 0.65rem; min-width: 82px; min-height: 40px; }
     body.fill-mode #atem-pill { padding: 4px 8px; font-size: 0.68rem; }
     body.fill-mode #status { width: 150px; max-width: 150px; flex-basis: 150px; padding: 3px 8px; font-size: 0.7rem; }
     body.fill-mode #cam-tabs { display: flex; }
-    body.fill-mode .cam-tab { padding: 11px 16px 9px; font-size: 0.88rem; }
+    body.fill-mode .cam-tab { padding: 11px 13px 9px; font-size: 0.88rem; }
     body.fill-mode main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
     body.fill-mode #preset-grid { flex: 1; align-content: start; justify-content: center; gap: 6px; }
     body.fill-mode #toolbar { margin-top: 8px; }
     body.fill-mode #toolbar { flex-shrink: 0; }
     body.fill-mode #toolbar-statuses { display: flex; }
-    body.fill-mode #toolbar-right { flex: 1 1 420px; }
+    body.fill-mode #toolbar-right { flex: 1 1 100%; width: 100%; }
     body.fill-mode .btn-primary { padding: 6px 12px; font-size: 0.76rem; }
     body.fill-mode .btn-ghost { padding: 5px 10px; font-size: 0.74rem; }
     body.fill-mode #scan-label { font-size: 0.68rem; }
@@ -1096,9 +1183,9 @@
     .cam-tab > * + *        { margin-left: 8px; }
     .atem-toggle-wrap > * + * { margin-left: 8px; }
     .preset-overlay > * + * { margin-left: 4px; }
-    #toolbar > * + *        { margin-left: 10px; }
-    #toolbar-right > * + *  { margin-left: 10px; }
-    #toolbar-statuses > * + * { margin-left: 8px; }
+    #toolbar > * + *        { margin-left: 0; }
+    #toolbar-right > * + *  { margin-left: 0; }
+    #toolbar-statuses > * + * { margin-left: 0; }
     #scan-bar > * + *       { margin-left: 12px; }
     .field > * + *          { margin-top: 4px; }
     #webcam-preview > * + * { margin-top: 4px; }
@@ -1108,12 +1195,6 @@
 <body>
 
 <header>
-  <div class="brand-icon">
-    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path d="M23 7l-7 5 7 5V7z"/>
-      <rect x="1" y="5" width="15" height="14" rx="2" ry="2"/>
-    </svg>
-  </div>
   <div class="brand-text">
     <h1>PTZ Preset Control</h1>
     <p>AVIPAS Camera &nbsp;&middot;&nbsp; VISCA over IP</p>
@@ -1122,23 +1203,21 @@
     <div id="fill-cam-strip" aria-label="Camera status controls"></div>
     <div id="cam-tabs"><!-- rendered by JS --></div>
     <div class="header-actions">
-      <button id="live-mode-btn" class="live" title="Toggle Live/Edit mode">Live</button>
       <button id="cut-live-btn" style="display:none" title="Cut active camera to ATEM program">Cut</button>
+      <button id="live-mode-btn" class="live" title="Toggle Live/Edit mode">Live</button>
       <button id="lock-live-btn" title="Lock camera to prevent preset movement"></button>
+      <button class="btn-ghost" id="btn-auto-cut" style="display:none">Auto Cut</button>
       <button id="fullscreen-btn" title="Toggle fullscreen">&#x26F6;</button>
     </div>
   </div>
 </header>
 
 <main>
-  <div id="preset-grid"><!-- rendered by JS --></div>
+  <div id="preset-stage">
+    <div id="preset-grid"><!-- rendered by JS --></div>
+  </div>
   <div id="toolbar">
     <button class="btn-primary" id="btn-scan">Scan All Presets</button>
-    <label id="toolbar-auto-cut-toggle" style="display:none">
-      <input id="f-auto-cut-enabled" type="checkbox" />
-      <span>Auto Enabled</span>
-    </label>
-    <button class="btn-ghost"    id="btn-auto-cut" style="display:none">Auto Cut</button>
     <button class="btn-ghost"    id="btn-edit">Edit Labels / Snap</button>
     <div id="capture-source-toggle" style="display:none">
       <button class="btn-ghost csrc-btn" data-src="active"   title="Capture from active camera">ACT</button>
@@ -1261,10 +1340,10 @@
       <input id="f-atem-ip" type="text" placeholder="192.168.1.200" autocomplete="off" spellcheck="false" />
     </div>
       <div class="field gsp-mobile-section active" data-mobile-tab="atem">
-        <label for="f-auto-cut-delay">Auto Cut Extra Delay (s)</label>
+        <label for="f-auto-cut-delay">Auto Cut Fallback Max (s)</label>
         <input id="f-auto-cut-delay" type="number" min="0" max="30" step="0.5" />
         <div class="field-note">
-          Auto Cut waits for confirmed camera stop first, then applies this optional extra delay before switching.
+          Confirmed Camera Stop cuts immediately. VISCA completion also cuts immediately. This max is used only if neither signal arrives, so Auto Cut can still fire by that time after recall starts.
         </div>
       </div>
       <label class="atem-toggle-wrap gsp-mobile-section active" data-mobile-tab="atem">
@@ -1321,9 +1400,13 @@
         <input id="f-cam-1-enabled" type="checkbox" class="cam-enable-cb" data-idx="1" />
         <span>Camera 2</span>
       </label>
-        <label class="atem-toggle-wrap camera-management-item">
+      <label class="atem-toggle-wrap camera-management-item">
         <input id="f-cam-2-enabled" type="checkbox" class="cam-enable-cb" data-idx="2" />
         <span>Camera 3</span>
+      </label>
+        <label class="atem-toggle-wrap camera-management-item">
+        <input id="f-cam-3-enabled" type="checkbox" class="cam-enable-cb" data-idx="3" />
+        <span>Camera 4</span>
       </label>
       </div>
     </div>
@@ -1405,6 +1488,7 @@
     { name: 'Camera 1', ip: '', port: 52381, viscaAddr: 1, atemInput: 1, streamUrl: '', usbDevice: '', enabled: true },
     { name: 'Camera 2', ip: '', port: 52381, viscaAddr: 1, atemInput: 2, streamUrl: '', usbDevice: '', enabled: true },
     { name: 'Camera 3', ip: '', port: 52381, viscaAddr: 1, atemInput: 3, streamUrl: '', usbDevice: '', enabled: true },
+    { name: 'Camera 4', ip: '', port: 52381, viscaAddr: 1, atemInput: 4, streamUrl: '', usbDevice: '', enabled: false },
   ];
 
   let state = {
@@ -1419,7 +1503,6 @@
     lockLiveMode: false,
     unlockOnExitLiveMode: true,
     atemFollows: 'preview',
-    autoCutEnabled: false,
     autoCutDelayMs: 0,
     previewSource: null,
     programSource: null,
@@ -1512,7 +1595,10 @@
       if (res.ok) {
         const s = await res.json();
         if (Array.isArray(s.cameras) && s.cameras.length) {
-          state.cameras  = s.cameras.map(c => ({ ...DEF_CAMERAS[0], ...c }));
+          state.cameras = DEF_CAMERAS.map((defaults, idx) => ({
+            ...defaults,
+            ...(s.cameras[idx] || {}),
+          }));
         }
         if (s.activeCam != null) state.activeCam = +s.activeCam;
         if (s.labels)   state.labels  = s.labels;
@@ -1529,7 +1615,6 @@
         if (s.unlockOnExitLiveMode != null) state.unlockOnExitLiveMode = !!s.unlockOnExitLiveMode;
         if (s.showAtemDebug != null) state.showAtemDebug = !!s.showAtemDebug;
         if (s.atemFollows)           state.atemFollows   = s.atemFollows;
-        if (s.autoCutEnabled != null) state.autoCutEnabled = !!s.autoCutEnabled;
         if (s.autoCutDelayMs != null) state.autoCutDelayMs = Math.max(0, +s.autoCutDelayMs || 0);
         if (s.atemOutputMap) state.atemOutputMap = normalizeAtemOutputMap(s.atemOutputMap);
         if (s.atemSourceLabels) state.atemSourceLabels = { ...s.atemSourceLabels };
@@ -1649,6 +1734,14 @@
     return 'Neither';
   }
 
+  function getCameraBusClass(idx) {
+    const status = getCameraAtemBusStatus(idx);
+    if (status === 'Program') return 'bus-live';
+    if (status === 'Preview') return 'bus-preview';
+    if (idx === state.activeCam) return 'bus-selected';
+    return 'bus-idle';
+  }
+
   function getCameraCaptureSourceSummary(idx) {
     const cam = state.cameras[idx];
     if (!cam) return 'Not configured';
@@ -1664,6 +1757,7 @@
       elAtemPill.className = 'disabled';
       elAtemPillText.textContent = 'ATEM Off';
       elAtemPill.title = 'ATEM integration is disabled';
+      updatePresetGridBusState();
       updateManualCutButton();
       updateAutoCutButton();
       return;
@@ -1673,6 +1767,7 @@
       elAtemPill.className = 'waiting';
       elAtemPillText.textContent = 'ATEM Wait';
       elAtemPill.title = 'ATEM is enabled but not connected yet';
+      updatePresetGridBusState();
       updateManualCutButton();
       updateAutoCutButton();
       return;
@@ -1693,6 +1788,7 @@
     const baseText = `ATEM P${program} V${preview}`;
     elAtemPillText.textContent = liveCameraName ? `${baseText} • 📹 ${liveCameraName} LIVE` : baseText;
     elAtemPill.title = `ATEM connected • Program ${program}${liveCameraName ? ` (${liveCameraName})` : ''} • Preview ${preview}`;
+    updatePresetGridBusState();
     updateManualCutButton();
     updateAutoCutButton();
   }
@@ -1829,14 +1925,24 @@
 
     if (onProgram) return 'LIVE';
     if (onPreview) return 'PVW';
+    if (idx === state.activeCam && state.liveMode) return 'SEL';
     if (idx === state.activeCam && !state.liveMode) return 'EDIT';
     return '';
+  }
+
+  function getCameraDotClass(idx) {
+    const badge = getCameraBadgeText(idx);
+    if (badge === 'LIVE') return 'live';
+    if (badge === 'PVW') return 'preview';
+    if (badge === 'SEL') return 'selected';
+    return 'idle';
   }
 
   function getCompactCameraState(idx) {
     const badge = getCameraBadgeText(idx);
     if (badge === 'LIVE') return { text: 'LIVE', className: 'live' };
     if (badge === 'PVW') return { text: 'PVW', className: 'preview' };
+    if (badge === 'SEL') return { text: 'SEL', className: 'selected' };
     return { text: 'IDLE', className: 'idle' };
   }
 
@@ -1879,8 +1985,13 @@
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'cam-tab' + (idx === state.activeCam ? ' active' : '');
+      btn.classList.add(getCameraBusClass(idx));
       btn.dataset.idx = idx;
       btn.title = cam.name;
+
+      const dot = document.createElement('span');
+      dot.className = `cam-state-dot ${getCameraDotClass(idx)}`;
+      dot.setAttribute('aria-hidden', 'true');
 
       const nameWrap = document.createElement('span');
       nameWrap.className = 'cam-name-wrap';
@@ -1889,35 +2000,12 @@
       nameEl.className = 'cam-name';
       nameEl.textContent = cam.name;
 
-      // Add badge for mode/ATEM indicator
-      let badgeText = '', badgeClass = '';
+      const badge = getCameraBadgeText(idx);
+      if (badge === 'LIVE') btn.classList.add('live');
+      else if (badge === 'PVW') btn.classList.add('preview');
+      else if (badge === 'EDIT') btn.classList.add('edit');
 
-      const onProgram = cameraMatchesAtemSource(idx, state.programSource);
-      const onPreview = cameraMatchesAtemSource(idx, state.previewSource);
-
-      if (onProgram) {
-        badgeText = 'LIVE';
-        badgeClass = 'live';
-        btn.classList.add('live');
-      } else if (onPreview) {
-        badgeText = 'PREVIEW';
-        badgeClass = 'preview';
-        btn.classList.add('preview');
-      }
-
-      if (!badgeText && idx === state.activeCam && !state.liveMode) {
-        badgeText = 'EDIT';
-        badgeClass = 'edit';
-        btn.classList.add('edit');
-      }
-
-      if (badgeText) {
-        const badge = document.createElement('span');
-        badge.className = 'cam-badge ' + badgeClass;
-        badge.textContent = badgeText;
-        nameWrap.appendChild(badge);
-      }
-
+      btn.appendChild(dot);
       nameWrap.appendChild(nameEl);
       btn.appendChild(nameWrap);
 
@@ -1948,6 +2036,7 @@
       elTabs.appendChild(btn);
     });
     renderFillCamStrip();
+    scheduleHeaderDensityUpdate();
   }
 
   function switchCamera(idx) {
@@ -2006,7 +2095,6 @@
   const elScanWaitMode = document.getElementById('f-scan-wait-mode');
   const elScanDwellField = document.getElementById('scan-dwell-field');
   const elDwell     = document.getElementById('f-dwell');
-  const elAutoCutEnabled = document.getElementById('f-auto-cut-enabled');
   const elAutoCutDelay = document.getElementById('f-auto-cut-delay');
 
   function updateScanWaitModeUi() {
@@ -2057,7 +2145,6 @@
     if (elScanWaitMode) elScanWaitMode.value = state.scanWaitMode;
     elAtemEnabled.checked = !!state.atem.enabled;
     elAtemIp.value        = state.atem.ip || '';
-    if (elAutoCutEnabled) elAutoCutEnabled.checked = !!state.autoCutEnabled;
     if (elAutoCutDelay) elAutoCutDelay.value = String((state.autoCutDelayMs || 0) / 1000);
     updateAtemPill();
     elUsbDevice.value = cam.usbDevice || '';
@@ -2086,7 +2173,6 @@
     state.scanWaitMode = elScanWaitMode?.value === 'dwell' ? 'dwell' : 'settle';
     state.atem.enabled = elAtemEnabled.checked;
     state.atem.ip      = elAtemIp.value.trim();
-    state.autoCutEnabled = !!(elAutoCutEnabled && elAutoCutEnabled.checked);
     state.autoCutDelayMs = Math.max(0, Math.round(((parseFloat(elAutoCutDelay?.value || '0') || 0) * 1000)));
     updateCameraStatusHints();
     updateScanWaitModeUi();
@@ -2115,14 +2201,6 @@
     updateCaptureOutputLabel();
   });
   elAtemIp.addEventListener('change', () => { saveCameraSettings(); schedSave(); });
-  if (elAutoCutEnabled) {
-    elAutoCutEnabled.addEventListener('change', () => {
-      saveCameraSettings();
-      if (!state.autoCutEnabled) setAutoCutArmed(false);
-      schedSave();
-      updateToolbarVisibility();
-    });
-  }
   if (elAutoCutDelay) {
     elAutoCutDelay.addEventListener('change', () => {
       saveCameraSettings();
@@ -2190,7 +2268,6 @@
   const elCaptureToggle = document.getElementById('capture-source-toggle');
   const elAutoCutBtn = document.getElementById('btn-auto-cut');
   const elCutLiveBtn = document.getElementById('cut-live-btn');
-  const elAutoCutEnabledToggle = document.getElementById('toolbar-auto-cut-toggle');
   let autoCutArmed = false;
   let autoCutTimer = null;
   let autoCutPending = null;
@@ -2213,7 +2290,7 @@
   }
 
   function canArmAutoCut() {
-    return !!state.atem.enabled && !!state.autoCutEnabled && !!atemConnected;
+    return !!state.atem.enabled && !!atemConnected;
   }
 
   function getAutoCutPlan(camIdx) {
@@ -2235,7 +2312,6 @@
   function getAutoCutDebugState() {
     const source = getActiveCameraCutSource();
     if (!state.atem.enabled) return 'ATEM OFF';
-    if (!state.autoCutEnabled) return 'AUTO DISABLED';
     if (!atemConnected) return 'ATEM WAIT';
     if (!source) return 'NO SRC';
     if (autoCutArmed) return `ARM ${source}`;
@@ -2277,18 +2353,16 @@
       elAutoCutBtn.title = 'Enable ATEM to use Auto Cut';
     } else if (!atemConnected) {
       elAutoCutBtn.title = 'Wait for ATEM to connect';
-    } else if (!state.autoCutEnabled) {
-      elAutoCutBtn.title = 'Turn on Auto Enabled first';
     } else if (!source) {
       elAutoCutBtn.title = 'Set an ATEM source number for this camera first';
     } else if (autoCutArmed) {
       elAutoCutBtn.title = delayText === '0s'
-        ? `Armed: cut ${state.cameras[state.activeCam]?.name || 'camera'} to air when camera stop is confirmed`
-        : `Armed: cut ${state.cameras[state.activeCam]?.name || 'camera'} to air after confirmed stop + ${delayText}`;
+        ? `Armed: cut ${state.cameras[state.activeCam]?.name || 'camera'} to air when camera stop or VISCA completion is confirmed`
+        : `Armed: cut ${state.cameras[state.activeCam]?.name || 'camera'} to air when camera stop or VISCA completion is confirmed, or by ${delayText} max if neither arrives`;
     } else {
       elAutoCutBtn.title = delayText === '0s'
-        ? 'Arm Auto Cut (confirmed stop)'
-        : `Arm Auto Cut (confirmed stop + ${delayText})`;
+        ? 'Arm the next automatic cut (confirmed stop or VISCA completion)'
+        : `Arm the next automatic cut (confirmed stop or VISCA completion, with ${delayText} max fallback)`;
     }
   }
 
@@ -2349,23 +2423,34 @@
     }
   }
 
-  function scheduleAutoCut(preset, autoCutPlan) {
+  function scheduleAutoCut(preset, autoCutPlan, trigger = 'settled', recallElapsedMs = 0) {
     if (!autoCutPlan || !autoCutPlan.source) return;
     clearPendingAutoCut();
     const { source, camName, delayMs } = autoCutPlan;
-    if (delayMs > 0) {
+    const usingCompletionFallback = trigger === 'completion';
+    const usingTimeoutFallback = trigger === 'timeout';
+    const effectiveDelayMs = usingTimeoutFallback
+      ? Math.max(0, delayMs - Math.max(0, recallElapsedMs || 0))
+      : 0;
+    if (effectiveDelayMs > 0) {
       autoCutPending = { source, camName, preset };
       setAutoCutDebug(`WAIT ${source}`);
-      setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} after confirmed stop + ${(delayMs / 1000).toFixed(1).replace(/\.0$/, '')}s`, false);
+      const delayLabel = (effectiveDelayMs / 1000).toFixed(2).replace(/\.?0+$/, '');
+      setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} waiting up to ${delayLabel}s more for fallback max`, false);
       autoCutTimer = setTimeout(() => {
         const pending = autoCutPending;
         if (!pending) return;
         fireAutoCut(pending.source, pending.camName, pending.preset);
-      }, delayMs);
+      }, effectiveDelayMs);
       return;
     }
     setAutoCutDebug(`READY ${source}`);
-    setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} when camera stop is confirmed`, false);
+    const readyReason = usingCompletionFallback
+      ? 'on VISCA completion'
+      : usingTimeoutFallback
+        ? 'on fallback max timeout'
+        : 'when camera stop is confirmed';
+    setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} ${readyReason}`, false);
     void fireAutoCut(source, camName, preset);
   }
 
@@ -2374,11 +2459,6 @@
       if (!state.atem.enabled) {
         setStatus('error', 'Enable ATEM first');
         setAutoCutDebug('ATEM OFF');
-        return;
-      }
-      if (!state.autoCutEnabled) {
-        setStatus('error', 'Turn on Auto Enabled first');
-        setAutoCutDebug('AUTO DISABLED');
         return;
       }
       if (!atemConnected) {
@@ -2396,11 +2476,11 @@
       if (autoCutArmed) {
         const camName = state.cameras[state.activeCam]?.name || 'camera';
         setAutoCutDebug(`ARM ${source}`);
-        if ((state.autoCutDelayMs || 0) > 0) {
-          setStatus('success', `Auto Cut armed for ${camName} after confirmed stop + ${getAutoCutDelaySeconds()}s`);
-        } else {
-          setStatus('success', `Auto Cut armed for ${camName} on confirmed camera stop`);
-        }
+        const fallbackDelay = Math.max(0, state.autoCutDelayMs || 0);
+        const fallbackText = fallbackDelay > 0
+          ? ` with ${getAutoCutDelaySeconds()}s max fallback if nothing confirms`
+          : '';
+        setStatus('success', `Next cut armed for ${camName} on confirmed stop or VISCA completion${fallbackText}`);
       } else {
         setAutoCutDebug('OFF');
       }
@@ -2417,13 +2497,6 @@
   function updateToolbarVisibility() {
     const btnScanEl = document.getElementById('btn-scan');
     if (btnScanEl) btnScanEl.style.display = state.liveMode ? 'none' : '';
-    if (elAutoCutEnabledToggle) {
-      elAutoCutEnabledToggle.style.display = state.atem.enabled ? 'inline-flex' : 'none';
-      elAutoCutEnabledToggle.classList.toggle('enabled', !!state.autoCutEnabled);
-      elAutoCutEnabledToggle.title = state.autoCutEnabled
-        ? 'Auto Cut feature enabled'
-        : 'Enable Auto Cut before arming';
-    }
     if (elAutoCutBtn) elAutoCutBtn.style.display = state.atem.enabled ? '' : 'none';
     if (elCaptureToggle) {
       elCaptureToggle.style.display =
@@ -2431,6 +2504,7 @@
     }
     updateManualCutButton();
     updateAutoCutButton();
+    scheduleHeaderDensityUpdate();
   }
 
   // Restore capture source preference and wire up toggle buttons
@@ -2456,9 +2530,11 @@
     updateLockIcon = function() {
       if (state.lockLiveMode) {
         elLockLiveBtn.textContent = '🔒 Locked';
+        elLockLiveBtn.title = 'Live camera movement is blocked';
         elLockLiveBtn.classList.add('locked');
       } else {
-        elLockLiveBtn.textContent = '🔓 Unlock';
+        elLockLiveBtn.textContent = '⚠ Unlocked';
+        elLockLiveBtn.title = 'Live camera movement is allowed';
         elLockLiveBtn.classList.remove('locked');
       }
     };
@@ -3015,6 +3091,7 @@
   }
 
   // ── Preset grid ────────────────────────────────────────────────────────────
+  const elPresetStage = document.getElementById('preset-stage');
   const elGrid = document.getElementById('preset-grid');
   let editMode = false;
   const imageVersions = Object.create(null);
@@ -3038,6 +3115,7 @@
     elGrid.innerHTML = '';
     presetNumbers().forEach(n => elGrid.appendChild(buildPresetBtn(n)));
     elGrid.style.gridTemplateColumns = `repeat(${state.gridCols}, 1fr)`;
+    updatePresetGridBusState();
   }
 
   function refreshGridForActiveCamera() {
@@ -3047,12 +3125,13 @@
       return;
     }
     nums.forEach(n => refreshPresetBtn(n, state.activeCam));
+    updatePresetGridBusState();
   }
 
   function updateFillGridMetrics() {
     const elMain = document.querySelector('main');
     const elToolbar = document.getElementById('toolbar');
-    if (!state.fillWindow || !elMain || !elToolbar) {
+    if (!state.fillWindow || !elMain || !elToolbar || !elPresetStage) {
       elGrid.style.justifyContent = '';
       elGrid.style.alignContent = '';
       elGrid.style.gridTemplateColumns = `repeat(${state.gridCols}, 1fr)`;
@@ -3064,11 +3143,13 @@
     if (!count) return;
 
     const gridStyles = getComputedStyle(elGrid);
+    const stageStyles = getComputedStyle(elPresetStage);
     const gap = parseFloat(gridStyles.gap || gridStyles.rowGap || '0') || 0;
     const toolbarStyles = getComputedStyle(elToolbar);
     const toolbarMarginTop = parseFloat(toolbarStyles.marginTop || '0') || 0;
+    const stagePadX = (parseFloat(stageStyles.paddingLeft || '0') || 0) + (parseFloat(stageStyles.paddingRight || '0') || 0);
 
-    const availableWidth = Math.max(0, elMain.clientWidth);
+    const availableWidth = Math.max(0, elPresetStage.clientWidth - stagePadX);
     const availableHeight = Math.max(
       0,
       elMain.clientHeight - elToolbar.offsetHeight - toolbarMarginTop
@@ -3125,19 +3206,45 @@
     elGrid.style.gridTemplateRows = `repeat(${best.rows}, ${best.tileHeight}px)`;
   }
 
+  let headerDensityFrame = 0;
+
+  function updateHeaderDensity() {
+    headerDensityFrame = 0;
+    const body = document.body;
+    if (!body) return;
+
+    if (state.fillWindow) {
+      body.classList.add('header-compact');
+      return;
+    }
+
+    body.classList.remove('header-compact');
+    const root = document.documentElement;
+    if (!root) return;
+
+    const needsCompactHeader = root.scrollHeight > (window.innerHeight + 2);
+    body.classList.toggle('header-compact', needsCompactHeader);
+  }
+
+  function scheduleHeaderDensityUpdate() {
+    if (headerDensityFrame) cancelAnimationFrame(headerDensityFrame);
+    headerDensityFrame = requestAnimationFrame(updateHeaderDensity);
+  }
+
   function applyGridLayout() {
     const elMain = document.querySelector('main');
     if (state.fillWindow) {
       elMain.style.maxWidth = 'none';
-      elMain.style.padding  = '8px';
+      elMain.style.padding  = '6px 8px 8px';
       document.body.classList.add('fill-mode');
     } else {
       elMain.style.maxWidth = '860px';
-      elMain.style.padding  = '20px';
+      elMain.style.padding  = '10px 20px 20px';
       document.body.classList.remove('fill-mode');
     }
     updateBuildIndicator();
     updateFillGridMetrics();
+    scheduleHeaderDensityUpdate();
   }
 
   function imgUrl(cam, preset) {
@@ -3180,6 +3287,12 @@
       ovName.textContent = state.labels[presetKey(cam, n)] || '';
     }
     refreshPresetImage(btn, cam, n);
+  }
+
+  function updatePresetGridBusState() {
+    if (!elPresetStage) return;
+    elPresetStage.classList.remove('bus-live', 'bus-preview', 'bus-selected', 'bus-idle');
+    elPresetStage.classList.add(getCameraBusClass(state.activeCam));
   }
 
   function resolveCaptureCamera() {
@@ -3361,11 +3474,14 @@
   async function recallPreset(n, btn) {
     const recallCamIdx = state.activeCam;
     const autoCutPlan = getAutoCutPlan(recallCamIdx);
-    const waitMode = autoCutPlan ? 'settle' : 'confirm';
+    const waitMode = autoCutPlan ? 'autocut' : 'confirm';
+    const recallStartedAt = (typeof performance !== 'undefined' && performance.now)
+      ? performance.now()
+      : Date.now();
     if (state.liveMode && state.lockLiveMode) {
       const isLiveCamera = cameraMatchesAtemSource(recallCamIdx, state.programSource);
       if (isLiveCamera) {
-        setStatus('error', 'Cannot move LIVE camera while lock is enabled');
+        setStatus('error', 'LIVE camera is locked. Switch cameras or tap Locked to go Unlocked before recalling a preset.');
         flash(btn, 'fail'); return;
       }
     }
@@ -3385,14 +3501,52 @@
       let msg = state.showAtemDebug
         ? `Preset ${n} recalled — ${data.message}`
         : `Preset ${n} recalled`;
-      if (autoCutPlan && !data.settled) {
-        msg += ' — Auto Cut skipped because camera stop was not confirmed';
+      const autoCutTrigger = !autoCutPlan
+        ? null
+        : data.settled
+          ? 'settled'
+          : data.sawCompletion
+            ? 'completion'
+            : 'timeout';
+      const autoCutReady = !!autoCutPlan && !!autoCutTrigger;
+      if (autoCutPlan && autoCutTrigger === 'completion' && !data.settled) {
+        msg += ' — Auto Cut using VISCA completion fallback';
+      }
+      if (autoCutPlan && autoCutTrigger === 'timeout') {
+        msg += ' — Auto Cut using fallback max timer';
       }
       setStatus('success', msg);
-      if (autoCutPlan && data.settled) {
-        scheduleAutoCut(n, autoCutPlan);
+      if (autoCutPlan && autoCutReady) {
+        const recallElapsedMs = Math.max(
+          0,
+          ((typeof performance !== 'undefined' && performance.now)
+            ? performance.now()
+            : Date.now()) - recallStartedAt
+        );
+        scheduleAutoCut(
+          n,
+          autoCutPlan,
+          autoCutTrigger,
+          recallElapsedMs
+        );
       }
     } else {
+      const recallElapsedMs = Math.max(
+        0,
+        ((typeof performance !== 'undefined' && performance.now)
+          ? performance.now()
+          : Date.now()) - recallStartedAt
+      );
+      const canUseFallbackMax = !!autoCutPlan
+        && (state.autoCutDelayMs || 0) > 0
+        && data.waitMode === 'autocut'
+        && /not confirmed/i.test(String(data.message || ''));
+      if (canUseFallbackMax) {
+        flash(btn, 'ok', 900);
+        setStatus('success', `Preset ${n} recalled — Auto Cut using fallback max timer`);
+        scheduleAutoCut(n, autoCutPlan, 'timeout', recallElapsedMs);
+        return;
+      }
       flash(btn, 'fail', 1100);
       const msg = state.showAtemDebug
         ? `Preset ${n} failed: ${data.message}`
@@ -3421,6 +3575,7 @@
   function hideScanBar() {
     elScanBar.classList.remove('visible');
     elScanFill.style.width = '0%';
+    scheduleHeaderDensityUpdate();
   }
 
   btnScan.addEventListener('click', () => {
@@ -3435,7 +3590,7 @@
     const cam = state.cameras[scanCamIdx];
     if (!cam.ip) { setStatus('error', 'Enter the camera IP address first'); return; }
     if (state.liveMode && state.lockLiveMode && cameraMatchesAtemSource(scanCamIdx, state.programSource)) {
-      setStatus('error', 'Cannot scan preset images for the LIVE camera while lock is enabled');
+      setStatus('error', 'LIVE camera is locked. Switch cameras or tap Locked to go Unlocked before scanning presets.');
       return;
     }
 
@@ -3454,6 +3609,7 @@
     btnScan.textContent = 'Cancel';
     btnScan.classList.add('cancel');
     elScanBar.classList.add('visible');
+    scheduleHeaderDensityUpdate();
 
     const captureErrors = [];
     let recallFailure = null;
@@ -3565,6 +3721,7 @@
 
   window.addEventListener('resize', () => {
     if (state.fillWindow) updateFillGridMetrics();
+    scheduleHeaderDensityUpdate();
   });
 })();
 </script>

--- a/public/index.html
+++ b/public/index.html
@@ -110,6 +110,16 @@
       background: rgba(34, 197, 94, 0.12);
     }
 
+    @keyframes pvw-set-flash {
+      0%   { box-shadow: 0 0 0 0 rgba(34,197,94,.8); border-color: var(--success); }
+      60%  { box-shadow: 0 0 0 6px rgba(34,197,94,0); border-color: var(--success); }
+      100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+    }
+
+    .fill-cam-indicator.setting-preview {
+      animation: pvw-set-flash 0.8s ease-out;
+    }
+
     .fill-cam-num {
       font-size: 0.68rem;
       font-weight: 700;
@@ -1946,6 +1956,18 @@
     return { text: 'IDLE', className: 'idle' };
   }
 
+  async function setAtemPreview(idx) {
+    if (!state.atem.enabled || !atemConnected) return;
+    const atemInput = getCameraAtemInput(idx);
+    if (!atemInput) return;
+    if (cameraMatchesAtemSource(idx, state.previewSource)) return;
+    await fetch('/api/atem/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ camIdx: idx }),
+    }).catch(() => ({}));
+  }
+
   function renderFillCamStrip() {
     if (!elFillCamStrip) return;
     elFillCamStrip.innerHTML = '';
@@ -1968,9 +1990,29 @@
 
       btn.appendChild(num);
       btn.appendChild(stateEl);
+
+      // Long-press (500 ms) to set ATEM preview
+      let lpTimer = null;
+      let lpHandled = false;
+      btn.addEventListener('pointerdown', () => {
+        lpTimer = setTimeout(() => {
+          lpTimer = null;
+          lpHandled = true;
+          btn.classList.add('setting-preview');
+          setTimeout(() => btn.classList.remove('setting-preview'), 800);
+          setAtemPreview(idx);
+        }, 500);
+      });
+      btn.addEventListener('pointerup',    () => { clearTimeout(lpTimer); lpTimer = null; });
+      btn.addEventListener('pointerleave', () => { clearTimeout(lpTimer); lpTimer = null; });
+      btn.addEventListener('pointermove',  () => { clearTimeout(lpTimer); lpTimer = null; });
+
       btn.addEventListener('click', () => {
+        if (lpHandled) { lpHandled = false; return; }
         if (idx !== state.activeCam) switchCamera(idx);
       });
+
+      btn.title = state.atem.enabled ? 'Click to switch · Hold to set preview' : 'Click to switch';
 
       elFillCamStrip.appendChild(btn);
     });
@@ -2009,19 +2051,41 @@
       nameWrap.appendChild(nameEl);
       btn.appendChild(nameWrap);
 
-      // Long-press rename for touch devices (500 ms hold)
+      // Long-press for touch devices:
+      // - 500 ms: set ATEM preview (when ATEM enabled and connected)
+      // - 700 ms: rename tab (always available)
       let longPressTimer = null;
       let longPressHandled = false;
       btn.addEventListener('pointerdown', () => {
         longPressTimer = setTimeout(() => {
           longPressTimer = null;
           longPressHandled = true;
-          openTabNameEditor(idx, nameEl, nameWrap);
+          if (state.atem.enabled && atemConnected) {
+            setAtemPreview(idx);
+            // schedule rename after an additional 200 ms (700 ms total)
+            longPressTimer = setTimeout(() => {
+              longPressTimer = null;
+              openTabNameEditor(idx, nameEl, nameWrap);
+            }, 200);
+          } else {
+            openTabNameEditor(idx, nameEl, nameWrap);
+          }
         }, 500);
       });
-      btn.addEventListener('pointerup',    () => clearTimeout(longPressTimer));
-      btn.addEventListener('pointerleave', () => clearTimeout(longPressTimer));
-      btn.addEventListener('pointermove',  () => clearTimeout(longPressTimer));
+      btn.addEventListener('pointerup', () => {
+        if (longPressTimer !== null) {
+          // In the 500–700 ms window: rename was pending, cancel it and
+          // reset longPressHandled so the click event can still fire normally.
+          clearTimeout(longPressTimer);
+          longPressTimer = null;
+          longPressHandled = false;
+        } else {
+          clearTimeout(longPressTimer);
+          longPressTimer = null;
+        }
+      });
+      btn.addEventListener('pointerleave', () => { clearTimeout(longPressTimer); longPressTimer = null; });
+      btn.addEventListener('pointermove',  () => { clearTimeout(longPressTimer); longPressTimer = null; });
 
       btn.addEventListener('click', () => {
         if (longPressHandled) { longPressHandled = false; return; }

--- a/public/index.html
+++ b/public/index.html
@@ -2005,9 +2005,11 @@
           setAtemPreview(idx);
         }, 500);
       });
-      btn.addEventListener('pointerup',    () => { clearTimeout(lpTimer); lpTimer = null; });
-      btn.addEventListener('pointerleave', () => { clearTimeout(lpTimer); lpTimer = null; });
-      btn.addEventListener('pointermove',  () => { clearTimeout(lpTimer); lpTimer = null; });
+      const clearFillLongPress = () => { clearTimeout(lpTimer); lpTimer = null; };
+      btn.addEventListener('pointerup',     clearFillLongPress);
+      btn.addEventListener('pointerleave',  clearFillLongPress);
+      btn.addEventListener('pointermove',   clearFillLongPress);
+      btn.addEventListener('pointercancel', clearFillLongPress);
 
       btn.addEventListener('click', () => {
         if (lpHandled) { lpHandled = false; return; }
@@ -2086,8 +2088,10 @@
           longPressTimer = null;
         }
       });
-      btn.addEventListener('pointerleave', () => { clearTimeout(longPressTimer); longPressTimer = null; });
-      btn.addEventListener('pointermove',  () => { clearTimeout(longPressTimer); longPressTimer = null; });
+      const clearTabLongPress = () => { clearTimeout(longPressTimer); longPressTimer = null; };
+      btn.addEventListener('pointerleave',  clearTabLongPress);
+      btn.addEventListener('pointermove',   clearTabLongPress);
+      btn.addEventListener('pointercancel', clearTabLongPress);
 
       btn.addEventListener('click', () => {
         if (longPressHandled) { longPressHandled = false; return; }
@@ -3619,7 +3623,7 @@
       const canUseFallbackMax = !!autoCutPlan
         && (state.autoCutDelayMs || 0) > 0
         && data.waitMode === 'autocut'
-        && /not confirmed/i.test(String(data.message || ''));
+        && data.commandAccepted === true;
       if (canUseFallbackMax) {
         flash(btn, 'ok', 900);
         setStatus('success', `Preset ${n} recalled — Auto Cut using fallback max timer`);

--- a/public/index.html
+++ b/public/index.html
@@ -3361,6 +3361,7 @@
   async function recallPreset(n, btn) {
     const recallCamIdx = state.activeCam;
     const autoCutPlan = getAutoCutPlan(recallCamIdx);
+    const waitMode = autoCutPlan ? 'settle' : 'confirm';
     if (state.liveMode && state.lockLiveMode) {
       const isLiveCamera = cameraMatchesAtemSource(recallCamIdx, state.programSource);
       if (isLiveCamera) {
@@ -3375,17 +3376,22 @@
     }
     flash(btn, 'busy');
     setStatus('busy', `Recalling preset ${n}…`, false);
-    const data = await doRecall(n, recallCamIdx, 'settle');
+    const data = await doRecall(n, recallCamIdx, waitMode);
     if (data.success) {
       flash(btn, 'ok', 900);
       if (state.showAtemDebug && recallCamIdx === state.activeCam && data.position) {
         applyDebugPositionData(data.position);
       }
-      const msg = state.showAtemDebug
+      let msg = state.showAtemDebug
         ? `Preset ${n} recalled — ${data.message}`
         : `Preset ${n} recalled`;
+      if (autoCutPlan && !data.settled) {
+        msg += ' — Auto Cut skipped because camera stop was not confirmed';
+      }
       setStatus('success', msg);
-      scheduleAutoCut(n, autoCutPlan);
+      if (autoCutPlan && data.settled) {
+        scheduleAutoCut(n, autoCutPlan);
+      }
     } else {
       flash(btn, 'fail', 1100);
       const msg = state.showAtemDebug

--- a/server.py
+++ b/server.py
@@ -80,6 +80,16 @@ DEFAULT_SETTINGS = {
             "usbDevice": "",
             "enabled": True,
         },
+        {
+            "name": "Camera 4",
+            "ip": "",
+            "port": 52381,
+            "viscaAddr": 1,
+            "atemInput": 4,
+            "streamUrl": "",
+            "usbDevice": "",
+            "enabled": False,
+        },
     ],
     "labels": {"0:1": "Stage Left", "0:5": "Wide"},
     "dwellMs": 3000,
@@ -89,7 +99,6 @@ DEFAULT_SETTINGS = {
     "lockLiveMode": False,
     "unlockOnExitLiveMode": True,
     "atemFollows": "preview",
-    "autoCutEnabled": False,
     "autoCutDelayMs": 0,
     "atemOutputMap": {
         "webcam": {"webcam": "", "streamUrl": ""},
@@ -120,6 +129,8 @@ def _normalize_recall_wait_mode(wait_mode: str | None) -> str:
         return "dwell"
     if wait_mode == "confirm":
         return "confirm"
+    if wait_mode == "autocut":
+        return "autocut"
     return "settle"
 
 
@@ -130,6 +141,10 @@ def _normalize_scan_wait_mode(wait_mode: str | None) -> str:
 
 def _probe_recall_command_succeeded(result: ProbeResult) -> bool:
     return result.error is None
+
+
+def _probe_autocut_ready(result: ProbeResult) -> bool:
+    return result.error is None and (result.settled or result.saw_completion)
 
 
 def _format_probe_message(result: ProbeResult, wait_mode: str) -> str:
@@ -154,6 +169,17 @@ def _format_probe_message(result: ProbeResult, wait_mode: str) -> str:
     elif wait_mode == "confirm":
         if completion is None and ack is None:
             parts.append("Command sent")
+    elif wait_mode == "autocut":
+        if result.settled and result.samples:
+            pos = _probe_motion_sample_to_dict(result.samples[-1])
+            parts.append(
+                "Settled "
+                f"pan {pos['pan_hex']} tilt {pos['tilt_hex']} zoom {pos['zoom_hex']}"
+            )
+        elif result.saw_completion:
+            parts.append("VISCA completion confirmed")
+        else:
+            parts.append("Motion stop was not confirmed")
     elif wait_mode == "dwell":
         parts.append("Manual dwell mode")
     if result.error:
@@ -190,6 +216,8 @@ def recall_visca_preset(
     success = (
         result.error is None and result.settled
         if wait_mode == "settle"
+        else _probe_autocut_ready(result)
+        if wait_mode == "autocut"
         else _probe_recall_command_succeeded(result)
     )
     payload = {

--- a/server.py
+++ b/server.py
@@ -478,6 +478,12 @@ def _send_atem_command(name: str, payload: bytes) -> tuple[bool, str]:
     return True, f"ATEM packet {packet_id} sent"
 
 
+def _send_atem_preview(source_id: int) -> tuple[bool, str]:
+    """Set ATEM ME1 preview bus to source_id via CPvI command."""
+    payload = bytes([0, 0]) + struct.pack(">H", source_id)
+    return _send_atem_command("CPvI", payload)
+
+
 def _wait_for_atem_program_source(source: int, timeout_s: float = 1.0) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -584,9 +590,7 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
             f"Cut command failed: {cut_message}",
         )
         return False, cut_message
-    if _wait_for_atem_program_source(
-        source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
-    ):
+    if _wait_for_atem_program_source(source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S):
         msg = f"Preview set to {source} • Cut executed"
         _set_atem_last_action("cut", "cut-confirm", source, reason, True, msg)
         return True, msg
@@ -605,9 +609,7 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
             False,
             f"Cut did not take and direct program switch failed: {program_message}",
         )
-    if _wait_for_atem_program_source(
-        source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
-    ):
+    if _wait_for_atem_program_source(source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S):
         msg = f"Cut did not take • direct program switch moved program to {source}"
         _set_atem_last_action(
             "cut", "program-fallback-confirm", source, reason, True, msg
@@ -1166,6 +1168,8 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_recall()
         elif path == "/atem/cut":
             self._handle_atem_cut()
+        elif path == "/api/atem/preview":
+            self._handle_atem_preview_post()
         elif path == "/settings":
             self._handle_settings_post()
         elif m := re.match(r"^/api/image/(\d+)/(\d+)$", path):
@@ -1252,6 +1256,31 @@ class Handler(BaseHTTPRequestHandler):
                 "lastAction": _get_atem_last_action(),
             },
         )
+
+    def _handle_atem_preview_post(self):
+        body = self._read_body()
+        try:
+            data = json.loads(body)
+            cam_idx = int(data.get("camIdx", -1))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            self._json(400, {"ok": False, "error": "Invalid JSON"})
+            return
+        cameras = load_settings().get("cameras", [])
+        if cam_idx < 0 or cam_idx >= len(cameras):
+            self._json(400, {"ok": False, "error": "Invalid camera index"})
+            return
+        atem_input = cameras[cam_idx].get("atemInput")
+        if not atem_input:
+            self._json(
+                400, {"ok": False, "error": "Camera has no ATEM input configured"}
+            )
+            return
+        if not _get_atem().get("connected"):
+            self._json(503, {"ok": False, "error": "ATEM not connected"})
+            return
+        ok, message = _send_atem_preview(int(atem_input))
+        status = 200 if ok else 503
+        self._json(status, {"ok": ok, "message": message})
 
     def _get_image(self, cam: int, preset: int):
         fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")

--- a/server.py
+++ b/server.py
@@ -211,7 +211,7 @@ def recall_visca_preset(
         stable_count=VISCA_STABLE_COUNT,
         inquiry_timeout=VISCA_INQUIRY_TIMEOUT_S,
         include_focus=False,
-        require_settle=wait_mode == "settle",
+        require_settle=wait_mode in ("settle", "autocut"),
         verbose=False,
     )
     success = (

--- a/server.py
+++ b/server.py
@@ -227,6 +227,7 @@ def recall_visca_preset(
         "settled": result.settled,
         "sawCompletion": result.saw_completion,
         "waitMode": wait_mode,
+        "commandAccepted": result.error is None,
         "position": (
             _probe_motion_sample_to_dict(result.samples[-1]) if result.samples else None
         ),

--- a/server.py
+++ b/server.py
@@ -108,14 +108,28 @@ VISCA_SETTLE_TIMEOUT_S = 8.0
 VISCA_POLL_INTERVAL_S = 0.2
 VISCA_STABLE_COUNT = 3
 VISCA_INQUIRY_TIMEOUT_S = 1.0
+ATEM_STATE_CONFIRM_TIMEOUT_S = 2.0
 
 
 def _visca_transport_for_port(port: int) -> str:
     return "raw-udp" if port == VISCA_RAW_UDP_PORT else "sony-udp"
 
 
+def _normalize_recall_wait_mode(wait_mode: str | None) -> str:
+    if wait_mode == "dwell":
+        return "dwell"
+    if wait_mode == "confirm":
+        return "confirm"
+    return "settle"
+
+
 def _normalize_scan_wait_mode(wait_mode: str | None) -> str:
-    return "dwell" if wait_mode == "dwell" else "settle"
+    normalized = _normalize_recall_wait_mode(wait_mode)
+    return normalized if normalized in {"dwell", "settle"} else "settle"
+
+
+def _probe_recall_command_succeeded(result: ProbeResult) -> bool:
+    return result.error is None
 
 
 def _format_probe_message(result: ProbeResult, wait_mode: str) -> str:
@@ -137,6 +151,9 @@ def _format_probe_message(result: ProbeResult, wait_mode: str) -> str:
         )
     elif wait_mode == "settle" and not result.settled:
         parts.append("Motion did not settle in time")
+    elif wait_mode == "confirm":
+        if completion is None and ack is None:
+            parts.append("Command sent")
     elif wait_mode == "dwell":
         parts.append("Manual dwell mode")
     if result.error:
@@ -153,7 +170,7 @@ def recall_visca_preset(
     camera_address: int = 1,
     wait_mode: str = "settle",
 ):
-    wait_mode = _normalize_scan_wait_mode(wait_mode)
+    wait_mode = _normalize_recall_wait_mode(wait_mode)
     result = _probe_preset(
         ip=ip,
         port=port,
@@ -170,8 +187,10 @@ def recall_visca_preset(
         require_settle=wait_mode == "settle",
         verbose=False,
     )
-    success = result.error is None and (
-        result.settled if wait_mode == "settle" else True
+    success = (
+        result.error is None and result.settled
+        if wait_mode == "settle"
+        else _probe_recall_command_succeeded(result)
     )
     payload = {
         "success": success,
@@ -477,7 +496,9 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
                 f"Preview command failed: {message}",
             )
             return False, message
-        if not _wait_for_atem_preview_source(source, timeout_s=1.0):
+        if not _wait_for_atem_preview_source(
+            source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
+        ):
             _set_atem_last_action(
                 "cut",
                 "preview-confirm",
@@ -500,7 +521,9 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
                     False,
                     f"Preview did not change to {source} and direct program switch failed: {program_message}",
                 )
-            if _wait_for_atem_program_source(source, timeout_s=1.0):
+            if _wait_for_atem_program_source(
+                source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
+            ):
                 msg = f"Preview did not change • direct program switch moved program to {source}"
                 _set_atem_last_action(
                     "cut", "program-fallback-confirm", source, reason, True, msg
@@ -533,7 +556,9 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
             f"Cut command failed: {cut_message}",
         )
         return False, cut_message
-    if _wait_for_atem_program_source(source, timeout_s=1.0):
+    if _wait_for_atem_program_source(
+        source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
+    ):
         msg = f"Preview set to {source} • Cut executed"
         _set_atem_last_action("cut", "cut-confirm", source, reason, True, msg)
         return True, msg
@@ -552,7 +577,9 @@ def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
             False,
             f"Cut did not take and direct program switch failed: {program_message}",
         )
-    if _wait_for_atem_program_source(source, timeout_s=1.0):
+    if _wait_for_atem_program_source(
+        source, timeout_s=ATEM_STATE_CONFIRM_TIMEOUT_S
+    ):
         msg = f"Cut did not take • direct program switch moved program to {source}"
         _set_atem_last_action(
             "cut", "program-fallback-confirm", source, reason, True, msg
@@ -1143,7 +1170,7 @@ class Handler(BaseHTTPRequestHandler):
         except (TypeError, ValueError):
             self._json(400, {"success": False, "message": "Invalid numeric parameter"})
             return
-        wait_mode = _normalize_scan_wait_mode(str(data.get("waitMode", "settle")))
+        wait_mode = _normalize_recall_wait_mode(str(data.get("waitMode", "settle")))
         if not ip:
             self._json(400, {"success": False, "message": "Camera IP is required"})
             return

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -333,6 +333,9 @@ class TestDefaultSettings(unittest.TestCase):
         for key in ("name", "ip", "port", "viscaAddr", "atemInput", "streamUrl", "usbDevice", "enabled"):
             self.assertIn(key, cam)
 
+    def test_default_has_four_cameras(self):
+        self.assertEqual(len(server.DEFAULT_SETTINGS["cameras"]), 4)
+
     def test_atem_shape(self):
         atem = server.DEFAULT_SETTINGS["atem"]
         self.assertIn("ip", atem)
@@ -494,6 +497,23 @@ class TestRecallProbeModes(unittest.TestCase):
         self.assertFalse(payload["success"])
         self.assertEqual(payload["message"], "Motion did not settle in time")
         self.assertEqual(payload["waitMode"], "settle")
+
+    def test_autocut_mode_accepts_visca_completion_without_settle(self):
+        probe_result = SimpleNamespace(
+            replies=[],
+            saw_completion=True,
+            settled=False,
+            samples=[],
+            error=None,
+        )
+        with patch("server._probe_preset", return_value=probe_result):
+            payload = server.recall_visca_preset(
+                "10.0.0.1", 52381, 4, 1, wait_mode="autocut"
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "VISCA completion confirmed")
+        self.assertEqual(payload["waitMode"], "autocut")
 
 
 # ── VISCA position inquiry ─────────────────────────────────────────────────────
@@ -806,6 +826,35 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertTrue(data["success"])
         self.assertEqual(data["waitMode"], "confirm")
         mock_recall.assert_called_once_with("10.0.0.1", 52381, 5, 1, "confirm")
+
+    def test_recall_autocut_mode_passed_through(self):
+        payload = json.dumps(
+            {
+                "ip": "10.0.0.1",
+                "port": 52381,
+                "camera": 1,
+                "preset": 5,
+                "waitMode": "autocut",
+            }
+        ).encode()
+        with patch(
+            "server.recall_visca_preset",
+            return_value={
+                "success": True,
+                "message": "VISCA completion confirmed",
+                "settled": False,
+                "sawCompletion": True,
+                "waitMode": "autocut",
+                "position": None,
+            },
+        ) as mock_recall:
+            status, body = self.srv.post("/recall", payload)
+
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["waitMode"], "autocut")
+        mock_recall.assert_called_once_with("10.0.0.1", 52381, 5, 1, "autocut")
 
     # ── image API ──────────────────────────────────────────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ import struct
 import tempfile
 import threading
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import server
@@ -99,8 +100,12 @@ class TestAtemPackets(unittest.TestCase):
         self.assertEqual(mock_send.call_count, 2)
         self.assertEqual(mock_send.call_args_list[0].args[0], "CPvI")
         self.assertEqual(mock_send.call_args_list[1].args[0], "DCut")
-        mock_wait_preview.assert_called_once_with(7, timeout_s=1.0)
-        mock_wait.assert_called_once_with(7, timeout_s=1.0)
+        mock_wait_preview.assert_called_once_with(
+            7, timeout_s=server.ATEM_STATE_CONFIRM_TIMEOUT_S
+        )
+        mock_wait.assert_called_once_with(
+            7, timeout_s=server.ATEM_STATE_CONFIRM_TIMEOUT_S
+        )
 
     def test_cut_atem_to_source_falls_back_to_direct_program_switch(self):
         with patch(
@@ -124,8 +129,12 @@ class TestAtemPackets(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIn("direct program switch", message)
         self.assertEqual([call.args[0] for call in mock_send.call_args_list], ["CPvI", "CPgI"])
-        mock_wait_preview.assert_called_once_with(9, timeout_s=1.0)
-        mock_wait.assert_called_once_with(9, timeout_s=1.0)
+        mock_wait_preview.assert_called_once_with(
+            9, timeout_s=server.ATEM_STATE_CONFIRM_TIMEOUT_S
+        )
+        mock_wait.assert_called_once_with(
+            9, timeout_s=server.ATEM_STATE_CONFIRM_TIMEOUT_S
+        )
 
     def test_cut_atem_to_source_returns_false_when_program_never_confirms(self):
         with patch(
@@ -448,6 +457,45 @@ class TestViscaPackets(unittest.TestCase):
         self.assertIn("Completion", msg)
 
 
+class TestRecallProbeModes(unittest.TestCase):
+    def test_confirm_mode_treats_command_send_as_success(self):
+        probe_result = SimpleNamespace(
+            replies=[],
+            saw_completion=False,
+            settled=False,
+            samples=[],
+            error=None,
+        )
+        with patch("server._probe_preset", return_value=probe_result) as mock_probe:
+            payload = server.recall_visca_preset(
+                "10.0.0.1", 52381, 4, 1, wait_mode="confirm"
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "Command sent")
+        self.assertEqual(payload["waitMode"], "confirm")
+        self.assertFalse(payload["settled"])
+        self.assertFalse(payload["sawCompletion"])
+        self.assertFalse(mock_probe.call_args.kwargs["require_settle"])
+
+    def test_settle_mode_still_requires_confirmed_stop(self):
+        probe_result = SimpleNamespace(
+            replies=[],
+            saw_completion=True,
+            settled=False,
+            samples=[],
+            error=None,
+        )
+        with patch("server._probe_preset", return_value=probe_result):
+            payload = server.recall_visca_preset(
+                "10.0.0.1", 52381, 4, 1, wait_mode="settle"
+            )
+
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["message"], "Motion did not settle in time")
+        self.assertEqual(payload["waitMode"], "settle")
+
+
 # ── VISCA position inquiry ─────────────────────────────────────────────────────
 
 
@@ -729,6 +777,35 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertTrue(data["success"])
         self.assertEqual(data["waitMode"], "dwell")
         mock_recall.assert_called_once_with("10.0.0.1", 1259, 5, 1, "dwell")
+
+    def test_recall_confirm_mode_passed_through(self):
+        payload = json.dumps(
+            {
+                "ip": "10.0.0.1",
+                "port": 52381,
+                "camera": 1,
+                "preset": 5,
+                "waitMode": "confirm",
+            }
+        ).encode()
+        with patch(
+            "server.recall_visca_preset",
+            return_value={
+                "success": True,
+                "message": "Command sent",
+                "settled": False,
+                "sawCompletion": False,
+                "waitMode": "confirm",
+                "position": None,
+            },
+        ) as mock_recall:
+            status, body = self.srv.post("/recall", payload)
+
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["waitMode"], "confirm")
+        mock_recall.assert_called_once_with("10.0.0.1", 52381, 5, 1, "confirm")
 
     # ── image API ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Base: `origin/DEV` (includes PR #40 — record camera absolute position)
- Merged: PR #36 `copilot/codex-auto-cut-redo-changes` (long-press ATEM preview + full codex/auto-cut workflow)
- Supersedes and closes: PR #35, PR #39, PR #41

## What's included

- **Long-press camera tab → set ATEM preview bus** (500 ms hold, `setAtemPreview()`, `/api/atem/preview` route)
- **Full auto-cut workflow** — arm/disarm, DCut dispatch, `ATEM_STATE_CONFIRM_TIMEOUT_S` (2.0 s), recall wait-mode improvements, autocut probe logic
- **4-camera default config**
- **Camera absolute position recording** on image save/capture (`positions` in settings, preset button tooltips)
- `_try_record_position` + positions persistence (from DEV/PR #40)

Note: `autoCutEnabled` is intentionally absent — auto-cut is controlled solely by the ARM button when ATEM is enabled and connected.

## Verification

- [x] `ruff check server.py` — clean
- [x] `python -m py_compile server.py` — no errors
- [x] `uv run pytest tests/test_frontend_contracts.py` — 5/5 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_015FDZYUCahGQvURURgLwtbh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera bus-state visuals (Program/Preview/Selected/Idle), long‑press preview control, and a fourth camera added (disabled by default)

* **Improvements**
  * Trigger‑aware auto‑cut scheduling with fallback timing and refined arming rules; ATEM confirmation timing made more robust; compact header and tighter control styling; more reliable preview/cut behavior to reduce misleading UI state

* **Documentation**
  * Guidance clarifying ATEM-driven UI status and recommended action‑ordering/queueing to avoid conflicting requests

* **Tests**
  * New tests for default camera count, ATEM confirmation timing, and VISCA recall wait modes (confirm/settle/autocut)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->