### PR TITLE
Add test coverage for #37 and #38 (position recording & snap-on-drift)

### DIFF
--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -67,6 +67,20 @@ class TestFrontendContracts(unittest.TestCase):
         # position shown as tooltip on preset button
         self.assertIn("Pan: ${pos.pan_hex}  Tilt: ${pos.tilt_hex}  Zoom: ${pos.zoom_hex}", self.html)
 
+    def test_snap_on_drift(self):
+        # state and threshold
+        self.assertIn("const snapNeeded = Object.create(null);", self.html)
+        self.assertIn("const SNAP_POSITION_THRESHOLD = 10;", self.html)
+        # helper functions exist
+        self.assertIn("function posDiff(a, b)", self.html)
+        self.assertIn("function clearSnapNeeded(cam, preset)", self.html)
+        # drift check triggered after successful recall
+        self.assertIn("checkPositionAfterRecall(n, recallCamIdx);", self.html)
+        # needs-snap class applied when drift detected
+        self.assertIn("btn.classList.add('needs-snap');", self.html)
+        # needs-snap cleared after a new capture
+        self.assertIn("clearSnapNeeded(cam, preset);", self.html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -522,6 +522,7 @@ class TestTryRecordPosition(unittest.TestCase):
     def _settings_with_ip(self, ip="10.0.0.1"):
         s = dict(server.DEFAULT_SETTINGS)
         s["cameras"] = [dict(server.DEFAULT_SETTINGS["cameras"][0], ip=ip)]
+        s["positions"] = {}
         return s
 
     def test_returns_none_when_no_ip(self):
@@ -647,8 +648,11 @@ class TestHTTPRoutes(unittest.TestCase):
         cls.srv.__exit__(None, None, None)
 
     def setUp(self):
-        # Reset settings to defaults before each test for isolation
-        server.write_settings(dict(server.DEFAULT_SETTINGS))
+        # Reset settings to defaults before each test for isolation.
+        # Use a fresh positions dict so TestTryRecordPosition mutation doesn't bleed in.
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["positions"] = {}
+        server.write_settings(settings)
 
     # ── static & settings ──────────────────────────────────────────────────────
 
@@ -967,6 +971,31 @@ class TestHTTPRoutes(unittest.TestCase):
         # Position should be cleared
         saved = server.load_settings()
         self.assertNotIn("0:5", saved.get("positions", {}))
+
+    # ── GET /api/image/{cam}/{preset}/position ─────────────────────────────────
+
+    def test_get_image_position_no_data_returns_404(self):
+        status, body = self.srv.get("/api/image/0/5/position")
+        self.assertEqual(status, 404)
+        data = json.loads(body)
+        self.assertFalse(data["ok"])
+
+    def test_get_image_position_returns_stored_data(self):
+        server.write_settings(self._settings_with_camera_ip())
+        fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 20
+        with patch(
+            "server.inquire_visca_absolute_position",
+            return_value=(True, self._MOCK_POSITION),
+        ):
+            self.srv.post("/api/image/0/5", fake_jpeg, "image/jpeg")
+
+        status, body = self.srv.get("/api/image/0/5/position")
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["pan_hex"], "1234")
+        self.assertEqual(data["tilt_hex"], "5678")
+        self.assertEqual(data["zoom_hex"], "00AA")
 
     # ── 404 paths ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Both features were already implemented in previous PRs (#40, #39) but the issues were never closed and test coverage was incomplete.

- **Frontend contract tests** for the snap-on-drift feature: `snapNeeded`, `SNAP_POSITION_THRESHOLD`, `posDiff`, `clearSnapNeeded`, `checkPositionAfterRecall`, and the `needs-snap` CSS hook
- **Server tests** for `GET /api/image/{cam}/{preset}/position` — the stored-position endpoint had no coverage at all
- **Fix pre-existing test isolation bug**: `_settings_with_ip` and `TestHTTPRoutes.setUp` were shallow-copying `DEFAULT_SETTINGS`, causing `_try_record_position` to mutate the module-level `positions` dict and bleed state into later tests

## Test plan

- [ ] `uv run pytest tests/test_frontend_contracts.py tests/test_server.py` — 85 tests, all pass
- [ ] `ruff check server.py` — clean
- [ ] `python -m py_compile server.py` — clean

Closes #37, closes #38

https://claude.ai/code/session_01Ut6DEFVinaXpjUwCNyRWRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut6DEFVinaXpjUwCNyRWRd)_