### PR TITLE
Add Active Cam capture mode (issue #44)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1368,7 +1368,17 @@
         <div class="field" style="flex-shrink:0;">
           <label for="f-capture-output">PTZ scan uses:</label>
           <select id="f-capture-output">
+            <option value="activeCam">Active Cam</option>
             <option value="webcam">USB Webcam</option>
+            <option value="sdi1">SDI Out 1</option>
+            <option value="sdi2">SDI Out 2</option>
+            <option value="sdi3">SDI Out 3</option>
+            <option value="sdi4">SDI Out 4</option>
+          </select>
+        </div>
+        <div id="active-cam-aux-row" class="field" style="display:none; flex-shrink:0;">
+          <label for="f-active-cam-aux">Route to:</label>
+          <select id="f-active-cam-aux">
             <option value="sdi1">SDI Out 1</option>
             <option value="sdi2">SDI Out 2</option>
             <option value="sdi3">SDI Out 3</option>
@@ -1461,6 +1471,7 @@
     },
     atemSourceLabels: {},
     captureOutput: 'webcam',
+    activeCamAux: 'sdi1',
     positions: {},
     // Runtime ATEM AUX sources (not persisted, updated via SSE)
     aux1Source: 0,
@@ -1511,6 +1522,7 @@
 
   function normalizeCaptureOutput(value) {
     const map = {
+      activeCam: 'activeCam',
       webcam: 'webcam',
       sdi1: 'sdi1',
       sdi2: 'sdi2',
@@ -1524,6 +1536,10 @@
       aux4: 'sdi4',
     };
     return map[value] || 'webcam';
+  }
+
+  function normalizeActiveCamAux(value) {
+    return ['sdi1', 'sdi2', 'sdi3', 'sdi4'].includes(value) ? value : 'sdi1';
   }
 
   // ── Server persistence ────────────────────────────────────────────────────
@@ -1557,6 +1573,7 @@
         if (s.atemOutputMap) state.atemOutputMap = normalizeAtemOutputMap(s.atemOutputMap);
         if (s.atemSourceLabels) state.atemSourceLabels = { ...s.atemSourceLabels };
         if (s.captureOutput) state.captureOutput = normalizeCaptureOutput(s.captureOutput);
+        if (s.activeCamAux) state.activeCamAux = normalizeActiveCamAux(s.activeCamAux);
         if (s.positions) state.positions = { ...s.positions };
       }
     } catch (_) {}
@@ -2725,11 +2742,12 @@
   let usbDevices = [];  // populated in boot; reused by renderOutputMapTable
 
   const ATEM_OUTPUT_KEYS = [
-    { key: 'webcam', label: 'USB Webcam' },
-    { key: 'sdi1',   label: 'SDI Out 1' },
-    { key: 'sdi2',   label: 'SDI Out 2' },
-    { key: 'sdi3',   label: 'SDI Out 3' },
-    { key: 'sdi4',   label: 'SDI Out 4' },
+    { key: 'activeCam', label: 'Active Cam' },
+    { key: 'webcam',    label: 'USB Webcam' },
+    { key: 'sdi1',      label: 'SDI Out 1' },
+    { key: 'sdi2',      label: 'SDI Out 2' },
+    { key: 'sdi3',      label: 'SDI Out 3' },
+    { key: 'sdi4',      label: 'SDI Out 4' },
   ];
 
   function getPhysicalOutputLabel(key) {
@@ -2760,6 +2778,12 @@
   function updateCaptureOutputLabel() {
     const el = document.getElementById('capture-output-label');
     if (!el) return;
+    if (state.captureOutput === 'activeCam') {
+      const auxLabel = getPhysicalOutputLabel(state.activeCamAux);
+      el.textContent = `Scan source: active camera routed to ${auxLabel}`;
+      el.style.color = 'var(--label)';
+      return;
+    }
     const outputLabel = getPhysicalOutputLabel(state.captureOutput);
     const src = getOutputSource(state.captureOutput);
     const map = state.atemOutputMap[state.captureOutput] || {};
@@ -2781,7 +2805,7 @@
     const tbody = document.getElementById('output-map-body');
     if (!tbody) return;
     tbody.innerHTML = '';
-    ATEM_OUTPUT_KEYS.forEach(({ key, label }) => {
+    ATEM_OUTPUT_KEYS.filter(({ key }) => key !== 'activeCam').forEach(({ key, label }) => {
       const src = getOutputSource(key);
       const sCls   = sourceClass(key, src);
       const map    = state.atemOutputMap[key] || { webcam: '', streamUrl: '' };
@@ -2911,10 +2935,18 @@
     });
   }
 
+  function updateActiveCamAuxVisibility() {
+    const row = document.getElementById('active-cam-aux-row');
+    if (row) row.style.display = state.captureOutput === 'activeCam' ? '' : 'none';
+  }
+
   function loadCaptureSection() {
     const sel = document.getElementById('f-capture-output');
     if (sel) sel.value = state.captureOutput || 'webcam';
+    const auxSel = document.getElementById('f-active-cam-aux');
+    if (auxSel) auxSel.value = state.activeCamAux || 'sdi1';
     updateCaptureModeVisibility();
+    updateActiveCamAuxVisibility();
     renderOutputMapTable();
     updateCaptureOutputLabel();
   }
@@ -2924,8 +2956,18 @@
     elCaptureOutput.addEventListener('change', () => {
       state.captureOutput = elCaptureOutput.value;
       schedSave();
+      updateActiveCamAuxVisibility();
       updateCaptureOutputLabel();
       renderOutputMapTable();
+    });
+  }
+
+  const elActiveCamAux = document.getElementById('f-active-cam-aux');
+  if (elActiveCamAux) {
+    elActiveCamAux.addEventListener('change', () => {
+      state.activeCamAux = elActiveCamAux.value;
+      schedSave();
+      updateCaptureOutputLabel();
     });
   }
 
@@ -3022,9 +3064,13 @@
   // captureFrame priority: USB device (ffmpeg) > stream URL (playwright) > browser webcam
   // source = pre-resolved { webcam, streamUrl } object, or null to resolve from state
   async function captureFrame(cam, preset, source = null) {
-    const resolved = source ?? (state.atem.enabled
-      ? (state.atemOutputMap[state.captureOutput] || {})
-      : { webcam: state.cameras[cam]?.usbDevice || '', streamUrl: state.cameras[cam]?.streamUrl || '' });
+    const resolved = source ?? (
+      state.atem.enabled && state.captureOutput !== 'activeCam'
+        ? (state.atemOutputMap[state.captureOutput] || {})
+        : state.atem.enabled
+          ? (state.atemOutputMap[state.activeCamAux] || {})
+          : { webcam: state.cameras[cam]?.usbDevice || '', streamUrl: state.cameras[cam]?.streamUrl || '' }
+    );
 
     const usb = resolved.webcam || '';
     const url = resolved.streamUrl || '';
@@ -3071,6 +3117,13 @@
     }
 
     try {
+      if (state.atem.enabled && state.captureOutput === 'activeCam') {
+        const routeResult = await routeActiveCam(cam);
+        if (!routeResult.ok) {
+          setStatus('error', `Could not route camera: ${routeResult.error || routeResult.message}`);
+          return;
+        }
+      }
       const ok = await captureFrame(cam, preset);
 
       if (ok) {
@@ -3478,6 +3531,19 @@
     }
   });
 
+  async function routeActiveCam(camIdx) {
+    try {
+      const res = await fetch('/api/atem/aux-route', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ camIdx, aux: state.activeCamAux }),
+      });
+      return await res.json();
+    } catch (e) {
+      return { ok: false, error: e.message };
+    }
+  }
+
   // ── Recall ─────────────────────────────────────────────────────────────────
   // camIdx defaults to the current active camera; pass explicitly to lock during scan
   async function doRecall(preset, camIdx = state.activeCam, waitMode = 'settle') {
@@ -3572,13 +3638,25 @@
       return;
     }
 
+    if (state.atem.enabled && state.captureOutput === 'activeCam') {
+      setStatus('busy', 'Routing camera…', false);
+      const routeResult = await routeActiveCam(scanCamIdx);
+      if (!routeResult.ok) {
+        setStatus('error', `Could not route camera: ${routeResult.error || routeResult.message}`);
+        return;
+      }
+    }
+
+    const captureKey = (state.atem.enabled && state.captureOutput === 'activeCam')
+      ? state.activeCamAux
+      : state.captureOutput;
     const lockedSource = state.atem.enabled
-      ? { ...(state.atemOutputMap[state.captureOutput] || {}) }
+      ? { ...(state.atemOutputMap[captureKey] || {}) }
       : { webcam: cam.usbDevice || '', streamUrl: cam.streamUrl || '' };
     const hasServerSource = lockedSource.webcam || lockedSource.streamUrl;
     if (!hasServerSource && !videoStream) {
       const hint = state.atem.enabled
-        ? `Configure a USB device or stream URL for ${getPhysicalOutputLabel(state.captureOutput)} in Settings`
+        ? `Configure a USB device or stream URL for ${getPhysicalOutputLabel(captureKey)} in Settings`
         : 'Set a USB device, VDO.ninja URL, or browser webcam for this camera';
       setStatus('error', hint); return;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -3120,6 +3120,11 @@
       if (state.atem.enabled && state.captureOutput === 'activeCam') {
         const routeResult = await routeActiveCam(cam);
         if (!routeResult.ok) {
+          if (preset_btn) {
+            preset_btn.classList.remove('state-busy');
+            preset_btn.classList.add('state-fail');
+            setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
+          }
           setStatus('error', `Could not route camera: ${routeResult.error || routeResult.message}`);
           return;
         }

--- a/server.py
+++ b/server.py
@@ -100,6 +100,7 @@ DEFAULT_SETTINGS = {
     },
     "atemSourceLabels": {},
     "captureOutput": "webcam",
+    "activeCamAux": "sdi1",
     "positions": {},
 }
 
@@ -454,6 +455,22 @@ def _wait_for_atem_preview_source(source: int, timeout_s: float = 1.0) -> bool:
             return True
         time.sleep(0.05)
     return _get_atem().get("preview") == source
+
+
+def _send_atem_aux_source(aux_idx: int, source_id: int) -> tuple[bool, str]:
+    """Route an ATEM AUX output to a given source via CAuS command."""
+    # CAuS payload: mask=0x01, aux channel (0-based), source (big-endian uint16)
+    return _send_atem_command("CAuS", bytes([0x01, aux_idx]) + struct.pack(">H", source_id))
+
+
+def _wait_for_atem_aux_source(aux_idx: int, source: int, timeout_s: float = 1.0) -> bool:
+    key = f"aux{aux_idx + 1}"
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _get_atem().get(key) == source:
+            return True
+        time.sleep(0.05)
+    return _get_atem().get(key) == source
 
 
 def cut_atem_to_source(source: int, reason: str = "manual") -> tuple[bool, str]:
@@ -1155,6 +1172,8 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_atem_cut()
         elif path == "/api/atem/preview":
             self._handle_atem_preview_post()
+        elif path == "/api/atem/aux-route":
+            self._handle_atem_aux_route()
         elif path == "/settings":
             self._handle_settings_post()
         elif m := re.match(r"^/api/image/(\d+)/(\d+)$", path):
@@ -1284,6 +1303,62 @@ class Handler(BaseHTTPRequestHandler):
         ok, message = _send_atem_preview(atem_input)
         status = 200 if ok else 502
         self._json(status, {"ok": ok, "message": message, "source": atem_input})
+
+    def _handle_atem_aux_route(self):
+        body = self._read_body()
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self._json(400, {"ok": False, "error": "Invalid JSON"})
+            return
+
+        aux_key = str(data.get("aux", "")).strip()
+        aux_map = {"sdi1": 0, "sdi2": 1, "sdi3": 2, "sdi4": 3}
+        if aux_key not in aux_map:
+            self._json(400, {"ok": False, "error": "aux must be sdi1–sdi4"})
+            return
+        aux_idx = aux_map[aux_key]
+
+        try:
+            cam_idx = int(data.get("camIdx", -1))
+        except (TypeError, ValueError):
+            self._json(400, {"ok": False, "error": "Invalid camIdx"})
+            return
+
+        settings = load_settings()
+        cfg = settings.get("atem", {})
+        if not cfg.get("enabled"):
+            self._json(409, {"ok": False, "error": "ATEM is disabled in settings"})
+            return
+        if not _get_atem().get("connected"):
+            self._json(409, {"ok": False, "error": "ATEM is not connected"})
+            return
+
+        cams = settings.get("cameras", [])
+        if cam_idx < 0 or cam_idx >= len(cams):
+            self._json(404, {"ok": False, "error": "Camera not found"})
+            return
+
+        try:
+            atem_input = int(cams[cam_idx].get("atemInput") or 0)
+        except (TypeError, ValueError):
+            atem_input = 0
+        if not atem_input:
+            self._json(400, {"ok": False, "error": "Camera has no ATEM input configured"})
+            return
+
+        ok, message = _send_atem_aux_source(aux_idx, atem_input)
+        if not ok:
+            self._json(502, {"ok": False, "error": message})
+            return
+        confirmed = _wait_for_atem_aux_source(aux_idx, atem_input, timeout_s=1.0)
+        self._json(200, {
+            "ok": True,
+            "confirmed": confirmed,
+            "message": message,
+            "aux": aux_key,
+            "source": atem_input,
+        })
 
     def _get_image(self, cam: int, preset: int):
         fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")

--- a/server.py
+++ b/server.py
@@ -1358,11 +1358,23 @@ class Handler(BaseHTTPRequestHandler):
             self._json(502, {"ok": False, "error": message})
             return
         confirmed = _wait_for_atem_aux_source(aux_idx, atem_input, timeout_s=1.0)
+        if not confirmed:
+            self._json(
+                504,
+                {
+                    "ok": False,
+                    "confirmed": False,
+                    "error": f"ATEM did not confirm route on {aux_key}",
+                    "aux": aux_key,
+                    "source": atem_input,
+                },
+            )
+            return
         self._json(
             200,
             {
                 "ok": True,
-                "confirmed": confirmed,
+                "confirmed": True,
                 "message": message,
                 "aux": aux_key,
                 "source": atem_input,

--- a/server.py
+++ b/server.py
@@ -460,10 +460,14 @@ def _wait_for_atem_preview_source(source: int, timeout_s: float = 1.0) -> bool:
 def _send_atem_aux_source(aux_idx: int, source_id: int) -> tuple[bool, str]:
     """Route an ATEM AUX output to a given source via CAuS command."""
     # CAuS payload: mask=0x01, aux channel (0-based), source (big-endian uint16)
-    return _send_atem_command("CAuS", bytes([0x01, aux_idx]) + struct.pack(">H", source_id))
+    return _send_atem_command(
+        "CAuS", bytes([0x01, aux_idx]) + struct.pack(">H", source_id)
+    )
 
 
-def _wait_for_atem_aux_source(aux_idx: int, source: int, timeout_s: float = 1.0) -> bool:
+def _wait_for_atem_aux_source(
+    aux_idx: int, source: int, timeout_s: float = 1.0
+) -> bool:
     key = f"aux{aux_idx + 1}"
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -1344,7 +1348,9 @@ class Handler(BaseHTTPRequestHandler):
         except (TypeError, ValueError):
             atem_input = 0
         if not atem_input:
-            self._json(400, {"ok": False, "error": "Camera has no ATEM input configured"})
+            self._json(
+                400, {"ok": False, "error": "Camera has no ATEM input configured"}
+            )
             return
 
         ok, message = _send_atem_aux_source(aux_idx, atem_input)
@@ -1352,13 +1358,16 @@ class Handler(BaseHTTPRequestHandler):
             self._json(502, {"ok": False, "error": message})
             return
         confirmed = _wait_for_atem_aux_source(aux_idx, atem_input, timeout_s=1.0)
-        self._json(200, {
-            "ok": True,
-            "confirmed": confirmed,
-            "message": message,
-            "aux": aux_key,
-            "source": atem_input,
-        })
+        self._json(
+            200,
+            {
+                "ok": True,
+                "confirmed": confirmed,
+                "message": message,
+                "aux": aux_key,
+                "source": atem_input,
+            },
+        )
 
     def _get_image(self, cam: int, preset: int):
         fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -52,6 +52,8 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("e.g. Multiview", self.html)
         self.assertIn("Scan source:", self.html)
         self.assertIn("Scan Output", self.html)
+        self.assertIn("Active Cam", self.html)
+        self.assertIn("Route to:", self.html)
 
     def test_positions_state_and_capture_integration(self):
         # positions initialized in state


### PR DESCRIPTION
## Summary

- Adds **"Active Cam"** as a new option in the "PTZ scan uses:" dropdown
- Before a scan (or single-preset capture), the app sends an ATEM `CAuS` command to route the active PTZ camera to a user-configured capture AUX output, so the capture device always sees the correct camera
- A "Route to: SDI Out 1/2/3/4" selector (shown only when Active Cam is selected) lets the user specify which AUX output their capture device is connected to

## Changes

- **server.py**: `_send_atem_aux_source` / `_wait_for_atem_aux_source` helpers; `_handle_atem_aux_route` handler; `POST /api/atem/aux-route` route; `activeCamAux` in `DEFAULT_SETTINGS`
- **index.html**: `activeCam` capture output option; "Route to:" AUX selector (hidden unless Active Cam selected); `routeActiveCam()` helper; `scanAll()` and `capturePresetImage()` route before capture; `captureFrame()` source resolution updated; full settings load/save/UI wiring
- **tests**: assert "Active Cam" and "Route to:" present in HTML

## Test plan

- [ ] Select "Active Cam" in Settings → ATEM → "PTZ scan uses:" — confirm "Route to:" row appears
- [ ] Select "SDI Out 1/2/3/4" in Route to: — confirm the label updates
- [ ] Run a scan — confirm `POST /api/atem/aux-route` is called first and the correct ATEM AUX is set to the scanned camera's input
- [ ] Capture a single preset — confirm routing also occurs before capture
- [ ] Switch back to a fixed output (e.g. USB Webcam) — confirm "Route to:" row hides and old behaviour is unchanged
- [ ] Confirm `ruff check server.py`, `python -m py_compile server.py`, and `uv run pytest tests/test_frontend_contracts.py` all pass

**Note:** The `CAuS` ATEM command payload (`mask=0x01, aux_idx, source big-endian`) follows the atem-connection library spec and should be verified against a real ATEM switcher.

https://claude.ai/code/session_01RGdZu3cPTdp6ShKUB8jXdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGdZu3cPTdp6ShKUB8jXdU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Active Cam" capture output mode with a "Route to" dropdown to choose an ATEM AUX destination
  * Captures now route the selected camera to the chosen AUX, wait for confirmation, and then proceed
  * AUX selection is saved to and restored from settings

* **Tests**
  * Added frontend contract tests verifying the "Active Cam" UI labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->