### PR TITLE
Fix failing CI: update test expectations for new camera configuration

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1011,7 +1011,7 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(data["pan_hex"], "1234")
         self.assertEqual(data["tilt_hex"], "5678")
         self.assertEqual(data["zoom_hex"], "00AA")
-        mock_inquire.assert_called_once_with("10.0.0.9", 52381, 1)
+        mock_inquire.assert_called_once_with("10.0.0.9", 1259, 1)
 
     # ── position recording on capture ──────────────────────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1011,7 +1011,9 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(data["pan_hex"], "1234")
         self.assertEqual(data["tilt_hex"], "5678")
         self.assertEqual(data["zoom_hex"], "00AA")
-        mock_inquire.assert_called_once_with("10.0.0.9", 1259, 1)
+        expected_port = server.DEFAULT_SETTINGS["cameras"][0]["port"]
+        expected_visca_addr = server.DEFAULT_SETTINGS["cameras"][0]["viscaAddr"]
+        mock_inquire.assert_called_once_with("10.0.0.9", expected_port, expected_visca_addr)
 
     # ── position recording on capture ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Resolved failing CI by updating test expectations to match the new camera port configuration.

- Camera 1-3 ports were changed from 52381 to 1259 in DEFAULT_SETTINGS
- Updated test_position_success_returns_inquiry_payload to expect the new port value
- All 151 tests now pass

## Test Plan

✅ ruff format check passed
✅ ruff linting check passed  
✅ Python compilation check passed
✅ Settings schema validation passed
✅ All 151 unit/integration tests passed
✅ Frontend checks passed

---
_Generated by [Claude Code](https://claude.ai/code/session_019Vmzxz2WUFCZ3iunyN5Se6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to assert camera connection parameters using configured defaults (port and device address) instead of hardcoded values, improving test reliability and alignment with current configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->