### PR TITLE
Fix Playwright thread-binding issue in video capture

### DIFF
--- a/server.py
+++ b/server.py
@@ -25,11 +25,15 @@ from scripts.av1281_motion_probe import (
 )
 
 try:
-    from playwright.sync_api import sync_playwright as _sync_playwright
+    from playwright.sync_api import (
+        sync_playwright as _sync_playwright,
+        TimeoutError as _PlaywrightTimeoutError,
+    )
 
     _HAS_PLAYWRIGHT = True
 except ImportError:
     _HAS_PLAYWRIGHT = False
+    _PlaywrightTimeoutError = None  # type: ignore[assignment]
 
 try:
     import cv2 as _cv2
@@ -1024,7 +1028,13 @@ def _pw_worker() -> None:
         _logger.debug("Playwright initialized on dedicated worker thread")
     except Exception as e:
         _logger.warning(f"Failed to initialize Playwright: {e!r}")
+        if _pw_ctx is not None:
+            try:
+                _pw_ctx.stop()
+            except Exception:
+                pass
         _pw_ctx = None
+        _pw_browser = None
     finally:
         _pw_ready.set()
 
@@ -1040,6 +1050,23 @@ def _pw_worker() -> None:
                 result_queue.put(("error", e))
         except Exception as e:
             _logger.error(f"Playwright worker error: {e!r}")
+
+    # Cleanup on shutdown
+    if _pw_page is not None:
+        try:
+            _pw_page.close()
+        except Exception:
+            pass
+    if _pw_browser is not None:
+        try:
+            _pw_browser.close()
+        except Exception:
+            pass
+    if _pw_ctx is not None:
+        try:
+            _pw_ctx.stop()
+        except Exception:
+            pass
 
 
 def _pw_capture_url_impl(url: str) -> bytes:
@@ -1072,7 +1099,7 @@ def _pw_capture_url_impl(url: str) -> bytes:
             )
             _logger.debug(f"Capture: Video element ready for {redacted_url}")
             _pw_page_url = url
-        except TimeoutError:
+        except _PlaywrightTimeoutError:
             _logger.debug(
                 f"Capture: Video not ready after timeout, falling back to page screenshot for {redacted_url}"
             )

--- a/server.py
+++ b/server.py
@@ -1071,9 +1071,7 @@ def _pw_capture_url_impl(url: str) -> bytes:
             )
             _logger.debug(f"Capture: Video element ready for {redacted_url}")
         except Exception as e:
-            _logger.error(
-                f"Capture: Failed to load video from {redacted_url}: {e!r}"
-            )
+            _logger.error(f"Capture: Failed to load video from {redacted_url}: {e!r}")
             if _pw_page:
                 _logger.debug("Capture: Falling back to page screenshot")
             _pw_page_url = None

--- a/server.py
+++ b/server.py
@@ -997,86 +997,107 @@ def inquire_visca_pan_tilt_position(
 
 
 # ── Playwright capture ─────────────────────────────────────────────────────────
-_pw_lock = threading.Lock()
-_pw_ctx = None  # playwright instance
+_pw_queue = queue.Queue()  # requests for dedicated Playwright thread
+_pw_ctx = None  # playwright instance (lives on dedicated thread)
 _pw_browser = None
 _pw_page = None
 _pw_page_url = None
+_pw_ready = threading.Event()  # signals when Playwright is initialized
 
 
-def _init_playwright() -> None:
-    """Initialize Playwright in the main thread before the HTTP server starts.
-
-    This prevents thread-binding issues with Playwright's sync_api, which fails
-    when the context is created in one thread but accessed from another.
-    """
-    global _pw_ctx, _pw_browser
+def _pw_worker() -> None:
+    """Dedicated thread for Playwright operations to avoid thread-binding issues."""
+    global _pw_ctx, _pw_browser, _pw_page, _pw_page_url
     if not _HAS_PLAYWRIGHT:
+        _pw_ready.set()
         return
-    with _pw_lock:
-        if _pw_ctx is not None:
-            return
+    try:
+        _pw_ctx = _sync_playwright().start()
+        _pw_browser = _pw_ctx.chromium.launch(
+            headless=True,
+            args=[
+                "--autoplay-policy=no-user-gesture-required",
+                "--use-fake-ui-for-media-stream",
+            ],
+        )
+        _logger.debug("Playwright initialized on dedicated worker thread")
+    except Exception as e:
+        _logger.warning(f"Failed to initialize Playwright: {e!r}")
+        _pw_ctx = None
+    finally:
+        _pw_ready.set()
+
+    while True:
         try:
-            _pw_ctx = _sync_playwright().start()
-            _pw_browser = _pw_ctx.chromium.launch(
-                headless=True,
-                args=[
-                    "--autoplay-policy=no-user-gesture-required",
-                    "--use-fake-ui-for-media-stream",
-                ],
-            )
-            _logger.debug("Playwright initialized in main thread")
+            item = _pw_queue.get()
+            if item is None:  # Shutdown signal
+                break
+            url, result_queue = item
+            try:
+                result_queue.put(("success", _pw_capture_url_impl(url)))
+            except Exception as e:
+                result_queue.put(("error", e))
         except Exception as e:
-            _logger.warning(f"Failed to initialize Playwright: {e!r}")
-            _pw_ctx = None
-            _pw_browser = None
+            _logger.error(f"Playwright worker error: {e!r}")
+
+
+def _pw_capture_url_impl(url: str) -> bytes:
+    """Implementation of URL capture running on the dedicated Playwright thread."""
+    global _pw_page, _pw_page_url
+    # Redact URL for logging
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        redacted_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    except Exception:
+        redacted_url = "<redacted>"
+
+    if _pw_page is None or _pw_page_url != url:
+        if _pw_page:
+            try:
+                _pw_page.close()
+            except Exception:
+                pass
+        try:
+            _pw_page = _pw_browser.new_page()
+            _pw_page.goto(url, wait_until="domcontentloaded")
+            _logger.debug(f"Capture: Loaded URL {redacted_url}")
+            # wait up to 30s for a video element with decoded data (longer for vdo.ninja)
+            _pw_page.wait_for_function(
+                "() => { const v = document.querySelector('video'); "
+                "return v && v.readyState >= 2 && v.videoWidth > 0; }",
+                timeout=30_000,
+            )
+            _logger.debug(f"Capture: Video element ready for {redacted_url}")
+        except Exception as e:
+            _logger.error(
+                f"Capture: Failed to load video from {redacted_url}: {e!r}"
+            )
+            if _pw_page:
+                _logger.debug("Capture: Falling back to page screenshot")
+            _pw_page_url = None
+            raise
+        _pw_page_url = url
+    video = _pw_page.query_selector("video")
+    if video:
+        return video.screenshot(type="jpeg", quality=70)
+    return _pw_page.screenshot(type="jpeg", full_page=False)
 
 
 def _capture_url(url: str) -> bytes:
-    global _pw_ctx, _pw_browser, _pw_page, _pw_page_url
+    """Queue URL capture to the dedicated Playwright worker thread."""
+    if not _pw_ready.is_set():
+        raise RuntimeError("Playwright initializing; try again")
     if _pw_ctx is None:
         raise RuntimeError("Playwright not initialized; URL capture unavailable")
-    with _pw_lock:
-        # Redact URL for logging (remove query params that may contain tokens)
-        try:
-            from urllib.parse import urlparse
-
-            parsed = urlparse(url)
-            redacted_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-        except Exception:
-            redacted_url = "<redacted>"
-
-        if _pw_page is None or _pw_page_url != url:
-            if _pw_page:
-                try:
-                    _pw_page.close()
-                except Exception:
-                    pass
-            try:
-                _pw_page = _pw_browser.new_page()
-                _pw_page.goto(url, wait_until="domcontentloaded")
-                _logger.debug(f"Capture: Loaded URL {redacted_url}")
-                # wait up to 30s for a video element with decoded data (longer for vdo.ninja)
-                _pw_page.wait_for_function(
-                    "() => { const v = document.querySelector('video'); "
-                    "return v && v.readyState >= 2 && v.videoWidth > 0; }",
-                    timeout=30_000,
-                )
-                _logger.debug(f"Capture: Video element ready for {redacted_url}")
-            except Exception as e:
-                _logger.error(
-                    f"Capture: Failed to load video from {redacted_url}: {e!r}"
-                )
-                # Try fullpage screenshot as fallback
-                if _pw_page:
-                    _logger.debug("Capture: Falling back to page screenshot")
-                _pw_page_url = None  # force reload next time
-                raise
-            _pw_page_url = url
-        video = _pw_page.query_selector("video")
-        if video:
-            return video.screenshot(type="jpeg", quality=70)
-        return _pw_page.screenshot(type="jpeg", full_page=False)
+    # Queue the request and wait for result
+    result_queue = queue.Queue()
+    _pw_queue.put((url, result_queue))
+    status, result = result_queue.get(timeout=35)
+    if status == "error":
+        raise result
+    return result
 
 
 # ── USB device capture ─────────────────────────────────────────────────────────
@@ -1859,7 +1880,9 @@ if __name__ == "__main__":
     )
     logger = logging.getLogger(__name__)
     load_settings()  # ensure data/ and default settings.json exist
-    _init_playwright()  # Initialize Playwright in main thread before server starts
+    pw_thread = threading.Thread(target=_pw_worker, daemon=True, name="playwright")
+    pw_thread.start()
+    _pw_ready.wait()  # Wait for Playwright to initialize before starting server
     atem_thread = threading.Thread(target=_atem_loop, daemon=True, name="atem")
     atem_thread.start()
     host, port = "0.0.0.0", 5001

--- a/server.py
+++ b/server.py
@@ -1086,12 +1086,11 @@ def _pw_capture_url_impl(url: str) -> bytes:
 
 
 def _capture_url(url: str) -> bytes:
-    """Queue URL capture to the dedicated Playwright worker thread."""
-    if not _pw_ready.is_set():
-        raise RuntimeError("Playwright initializing; try again")
-    if _pw_ctx is None:
-        raise RuntimeError("Playwright not initialized; URL capture unavailable")
-    # Queue the request and wait for result
+    """Queue URL capture to the dedicated Playwright worker thread.
+
+    Assumes Playwright has been initialized (_pw_ctx is not None).
+    Call site should check before calling.
+    """
     result_queue = queue.Queue()
     _pw_queue.put((url, result_queue))
     status, result = result_queue.get(timeout=35)
@@ -1758,6 +1757,15 @@ class Handler(BaseHTTPRequestHandler):
                         {
                             "ok": False,
                             "error": "playwright not installed — run: pip install playwright && playwright install chromium",
+                        },
+                    )
+                    return
+                if _pw_ctx is None:
+                    self._json(
+                        503,
+                        {
+                            "ok": False,
+                            "error": "playwright failed to initialize; check server logs",
                         },
                     )
                     return

--- a/server.py
+++ b/server.py
@@ -1004,8 +1004,38 @@ _pw_page = None
 _pw_page_url = None
 
 
+def _init_playwright() -> None:
+    """Initialize Playwright in the main thread before the HTTP server starts.
+
+    This prevents thread-binding issues with Playwright's sync_api, which fails
+    when the context is created in one thread but accessed from another.
+    """
+    global _pw_ctx, _pw_browser
+    if not _HAS_PLAYWRIGHT:
+        return
+    with _pw_lock:
+        if _pw_ctx is not None:
+            return
+        try:
+            _pw_ctx = _sync_playwright().start()
+            _pw_browser = _pw_ctx.chromium.launch(
+                headless=True,
+                args=[
+                    "--autoplay-policy=no-user-gesture-required",
+                    "--use-fake-ui-for-media-stream",
+                ],
+            )
+            _logger.debug("Playwright initialized in main thread")
+        except Exception as e:
+            _logger.warning(f"Failed to initialize Playwright: {e!r}")
+            _pw_ctx = None
+            _pw_browser = None
+
+
 def _capture_url(url: str) -> bytes:
     global _pw_ctx, _pw_browser, _pw_page, _pw_page_url
+    if _pw_ctx is None:
+        raise RuntimeError("Playwright not initialized; URL capture unavailable")
     with _pw_lock:
         # Redact URL for logging (remove query params that may contain tokens)
         try:
@@ -1016,15 +1046,6 @@ def _capture_url(url: str) -> bytes:
         except Exception:
             redacted_url = "<redacted>"
 
-        if _pw_ctx is None:
-            _pw_ctx = _sync_playwright().start()
-            _pw_browser = _pw_ctx.chromium.launch(
-                headless=True,
-                args=[
-                    "--autoplay-policy=no-user-gesture-required",
-                    "--use-fake-ui-for-media-stream",
-                ],
-            )
         if _pw_page is None or _pw_page_url != url:
             if _pw_page:
                 try:
@@ -1838,6 +1859,7 @@ if __name__ == "__main__":
     )
     logger = logging.getLogger(__name__)
     load_settings()  # ensure data/ and default settings.json exist
+    _init_playwright()  # Initialize Playwright in main thread before server starts
     atem_thread = threading.Thread(target=_atem_loop, daemon=True, name="atem")
     atem_thread.start()
     host, port = "0.0.0.0", 5001

--- a/server.py
+++ b/server.py
@@ -1122,7 +1122,12 @@ def _capture_url(url: str) -> bytes:
     """
     result_queue = queue.Queue()
     _pw_queue.put((url, result_queue))
-    status, result = result_queue.get(timeout=_PW_CAPTURE_TIMEOUT_S)
+    try:
+        status, result = result_queue.get(timeout=_PW_CAPTURE_TIMEOUT_S)
+    except queue.Empty:
+        raise TimeoutError(
+            f"Playwright worker did not respond within {_PW_CAPTURE_TIMEOUT_S}s"
+        )
     if status == "error":
         raise result
     return result

--- a/server.py
+++ b/server.py
@@ -1071,13 +1071,16 @@ def _pw_capture_url_impl(url: str) -> bytes:
                 timeout=30_000,
             )
             _logger.debug(f"Capture: Video element ready for {redacted_url}")
+            _pw_page_url = url
+        except TimeoutError:
+            _logger.debug(
+                f"Capture: Video not ready after timeout, falling back to page screenshot for {redacted_url}"
+            )
+            _pw_page_url = url
         except Exception as e:
             _logger.error(f"Capture: Failed to load video from {redacted_url}: {e!r}")
-            if _pw_page:
-                _logger.debug("Capture: Falling back to page screenshot")
             _pw_page_url = None
             raise
-        _pw_page_url = url
     video = _pw_page.query_selector("video")
     if video:
         return video.screenshot(type="jpeg", quality=70)

--- a/server.py
+++ b/server.py
@@ -997,6 +997,7 @@ def inquire_visca_pan_tilt_position(
 
 
 # ── Playwright capture ─────────────────────────────────────────────────────────
+_PW_CAPTURE_TIMEOUT_S = 65  # includes goto + wait_for_function timeouts
 _pw_queue = queue.Queue()  # requests for dedicated Playwright thread
 _pw_ctx = None  # playwright instance (lives on dedicated thread)
 _pw_browser = None
@@ -1091,7 +1092,7 @@ def _capture_url(url: str) -> bytes:
     """
     result_queue = queue.Queue()
     _pw_queue.put((url, result_queue))
-    status, result = result_queue.get(timeout=35)
+    status, result = result_queue.get(timeout=_PW_CAPTURE_TIMEOUT_S)
     if status == "error":
         raise result
     return result
@@ -1758,6 +1759,15 @@ class Handler(BaseHTTPRequestHandler):
                         },
                     )
                     return
+                if not _pw_ready.is_set():
+                    self._json(
+                        503,
+                        {
+                            "ok": False,
+                            "error": "playwright initialization in progress; retry in a few moments",
+                        },
+                    )
+                    return
                 if _pw_ctx is None:
                     self._json(
                         503,
@@ -1888,7 +1898,11 @@ if __name__ == "__main__":
     load_settings()  # ensure data/ and default settings.json exist
     pw_thread = threading.Thread(target=_pw_worker, daemon=True, name="playwright")
     pw_thread.start()
-    _pw_ready.wait()  # Wait for Playwright to initialize before starting server
+    if not _pw_ready.wait(timeout=30):
+        logger.warning(
+            "Playwright initialization is still pending after 30s; "
+            "starting server with URL capture temporarily unavailable"
+        )
     atem_thread = threading.Thread(target=_atem_loop, daemon=True, name="atem")
     atem_thread.start()
     host, port = "0.0.0.0", 5001


### PR DESCRIPTION
## Summary
Fixed the `error('cannot switch to a different thread (which happens to have exited)')` error that was occurring during URL-based video capture (e.g., vdo.ninja streams).

## Root Cause
Playwright's `sync_api` creates a thread-bound context. When `_capture_url()` was called from HTTP request handler threads (running in a thread pool), Playwright failed when different threads tried to access the same context.

## Solution
Initialize Playwright eagerly in the main thread before the HTTP server starts, ensuring all request handlers use the same main-thread-bound context. This prevents the threading error.

## Changes
- Add `_init_playwright()` function to initialize Playwright in main thread
- Call it before starting `ThreadedHTTPServer`
- Remove redundant initialization logic from `_capture_url()`
- Add early error check if Playwright wasn't initialized

## Test Plan
- [x] Python syntax valid
- [x] Ruff linting passes
- [x] All frontend contract tests pass
- Manual testing: Verify URL capture works without threading errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01E311TonLbr2eQsXDY7bxEf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Browser-based capture now runs in a dedicated background worker so browser sessions are initialized once and reused for multiple requests, improving throughput and reducing per-request overhead.
* **Bug Fixes**
  * Capture requests now return a clear HTTP 503 when browser initialization is in progress or has failed, preventing hangs and hidden retries.
* **Behavior**
  * Startup waits briefly for the capture subsystem to become ready before handling requests, yielding more reliable and responsive screenshot/video captures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->