### PR TITLE
Sync post-merge joystick fixes from DEV

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1569,6 +1569,21 @@
              c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
   </svg>
 </button>
+
+<!-- Virtual Joystick for Touch Devices -->
+<div id="virtual-joystick-container" style="display:none; position:fixed; bottom:20px; left:20px; z-index:100; touch-action:none;">
+  <div id="virtual-joystick" style="position:relative; width:120px; height:120px; background:var(--surf2); border:2px solid var(--border); border-radius:50%; display:flex; align-items:center; justify-content:center; cursor:grab; user-select:none;">
+    <div id="joystick-center" style="position:absolute; width:40px; height:40px; background:var(--accent); border-radius:50%; top:50%; left:50%; transform:translate(-50%,-50%); transition:all 0.05s ease-out; box-shadow:0 2px 8px rgba(0,0,0,0.3);"></div>
+    <div style="position:absolute; width:100%; height:100%; border:1px dashed var(--border); border-radius:50%; opacity:0.3;"></div>
+  </div>
+  <div id="joystick-label" style="text-align:center; margin-top:8px; font-size:0.75rem; color:var(--muted); white-space:nowrap;">Pan/Tilt</div>
+  <button id="joystick-zoom-up" style="position:absolute; top:-40px; left:50%; transform:translateX(-50%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">+</button>
+  <button id="joystick-zoom-down" style="position:absolute; bottom:-40px; left:50%; transform:translateX(-50%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">−</button>
+</div>
+
+<!-- Virtual Joystick Toggle Button -->
+<button id="virtual-joystick-btn" style="display:none; position:fixed; bottom:20px; left:20px; z-index:99; padding:8px 12px; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:0.8rem; cursor:pointer;">Virtual Joystick</button>
+
 <script>
 (function () {
   'use strict';
@@ -2468,6 +2483,114 @@
       schedSave();
       updateAutoCutButton();
     });
+  }
+
+  // ── Virtual Joystick (Touch) ─────────────────────────────────────────────────
+  const elVirtualJoystick = document.getElementById('virtual-joystick');
+  const elJoystickCenter = document.getElementById('joystick-center');
+  const elVirtualJoystickBtn = document.getElementById('virtual-joystick-btn');
+  const elVirtualJoystickContainer = document.getElementById('virtual-joystick-container');
+  const elJoystickZoomUp = document.getElementById('joystick-zoom-up');
+  const elJoystickZoomDown = document.getElementById('joystick-zoom-down');
+
+  let virtualJoystickActive = false;
+  let virtualJoystickTouchId = null;
+
+  function showVirtualJoystick(show) {
+    virtualJoystickActive = show;
+    if (elVirtualJoystickContainer) {
+      elVirtualJoystickContainer.style.display = show ? 'block' : 'none';
+    }
+    if (elVirtualJoystickBtn) {
+      elVirtualJoystickBtn.style.display = !show ? 'block' : 'none';
+    }
+  }
+
+  if (elVirtualJoystickBtn) {
+    elVirtualJoystickBtn.addEventListener('click', () => {
+      showVirtualJoystick(true);
+      localStorage.setItem('ptz-virtual-joystick', 'true');
+    });
+  }
+
+  if (elVirtualJoystick) {
+    const joystickRect = { x: 0, y: 0, size: 120, radius: 60 };
+
+    function updateJoystickPosition(touchX, touchY) {
+      const rect = elVirtualJoystick.getBoundingClientRect();
+      joystickRect.x = rect.left;
+      joystickRect.y = rect.top;
+
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      let deltaX = touchX - centerX;
+      let deltaY = touchY - centerY;
+
+      const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+      const maxDistance = joystickRect.radius - 20;
+
+      if (distance > maxDistance) {
+        const ratio = maxDistance / distance;
+        deltaX *= ratio;
+        deltaY *= ratio;
+      }
+
+      elJoystickCenter.style.transform = `translate(calc(-50% + ${deltaX}px), calc(-50% + ${deltaY}px))`;
+
+      // Send pan/tilt commands based on joystick position
+      const pan = (deltaX / maxDistance) * 100;
+      const tilt = (deltaY / maxDistance) * 100;
+
+      _logger.debug(`Virtual joystick: pan=${pan.toFixed(0)}, tilt=${tilt.toFixed(0)}`);
+    }
+
+    function resetJoystick() {
+      elJoystickCenter.style.transform = 'translate(-50%, -50%)';
+    }
+
+    elVirtualJoystick.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      if (virtualJoystickTouchId !== null) return;
+
+      const touch = e.touches[0];
+      virtualJoystickTouchId = touch.identifier;
+      updateJoystickPosition(touch.clientX, touch.clientY);
+    }, { passive: false });
+
+    document.addEventListener('touchmove', (e) => {
+      if (virtualJoystickTouchId === null) return;
+
+      for (let i = 0; i < e.touches.length; i++) {
+        if (e.touches[i].identifier === virtualJoystickTouchId) {
+          e.preventDefault();
+          updateJoystickPosition(e.touches[i].clientX, e.touches[i].clientY);
+          break;
+        }
+      }
+    }, { passive: false });
+
+    document.addEventListener('touchend', (e) => {
+      for (let i = 0; i < e.changedTouches.length; i++) {
+        if (e.changedTouches[i].identifier === virtualJoystickTouchId) {
+          virtualJoystickTouchId = null;
+          resetJoystick();
+          break;
+        }
+      }
+    });
+
+    elVirtualJoystick.addEventListener('touchcancel', () => {
+      virtualJoystickTouchId = null;
+      resetJoystick();
+    });
+  }
+
+  // Show virtual joystick button on touch devices
+  if (window.matchMedia('(hover: none)').matches) {
+    if (elVirtualJoystickBtn && localStorage.getItem('ptz-virtual-joystick') !== 'false') {
+      elVirtualJoystickBtn.style.display = 'block';
+    }
   }
 
   // ── SSE ────────────────────────────────────────────────────────────────────

--- a/public/index.html
+++ b/public/index.html
@@ -2495,6 +2495,52 @@
 
   let virtualJoystickActive = false;
   let virtualJoystickTouchId = null;
+  let lastVirtualPtz = { pan: 0, tilt: 0, zoom: 0 };
+
+  function quantizePtzAxis(value) {
+    const n = Math.max(-1, Math.min(1, Number(value) || 0));
+    return Math.round(n * 10) / 10;
+  }
+
+  async function sendPtzDriveCommand(pan = 0, tilt = 0, zoom = 0) {
+    const next = {
+      pan: quantizePtzAxis(pan),
+      tilt: quantizePtzAxis(tilt),
+      zoom: quantizePtzAxis(zoom),
+    };
+
+    if (state.liveMode && state.lockLiveMode && cameraMatchesAtemSource(state.activeCam, state.programSource)) {
+      setStatus('error', 'LIVE camera is locked. Switch cameras or tap Locked to go Unlocked before moving.');
+      return false;
+    }
+
+    const cam = state.cameras[state.activeCam];
+    if (!cam || !cam.ip) {
+      setStatus('error', 'Enter the camera IP address first');
+      return false;
+    }
+    if (next.pan === lastVirtualPtz.pan && next.tilt === lastVirtualPtz.tilt && next.zoom === lastVirtualPtz.zoom) {
+      return true;
+    }
+
+    try {
+      const res = await fetch('/api/ptz/drive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ camIdx: state.activeCam, pan: next.pan, tilt: next.tilt, zoom: next.zoom }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) {
+        setStatus('error', data.error || data.message || 'PTZ move failed');
+        return false;
+      }
+      lastVirtualPtz = next;
+      return true;
+    } catch (err) {
+      setStatus('error', `PTZ move failed: ${err.message || err}`);
+      return false;
+    }
+  }
 
   function showVirtualJoystick(show) {
     virtualJoystickActive = show;
@@ -2538,15 +2584,15 @@
 
       elJoystickCenter.style.transform = `translate(calc(-50% + ${deltaX}px), calc(-50% + ${deltaY}px))`;
 
-      // Send pan/tilt commands based on joystick position
-      const pan = (deltaX / maxDistance) * 100;
-      const tilt = (deltaY / maxDistance) * 100;
-
-      _logger.debug(`Virtual joystick: pan=${pan.toFixed(0)}, tilt=${tilt.toFixed(0)}`);
+      const pan = deltaX / maxDistance;
+      const tilt = -(deltaY / maxDistance);
+      sendPtzDriveCommand(pan, tilt, 0);
+      console.debug('[PTZ] Virtual joystick:', { pan: pan.toFixed(2), tilt: tilt.toFixed(2) });
     }
 
     function resetJoystick() {
       elJoystickCenter.style.transform = 'translate(-50%, -50%)';
+      sendPtzDriveCommand(0, 0, 0);
     }
 
     elVirtualJoystick.addEventListener('touchstart', (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -1546,7 +1546,7 @@
     </div>
 
     <!-- Joystick/Gamepad Settings -->
-    <div id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem" style="display:none;">
+    <div id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem">
       <div class="gsp-section-title" style="margin-bottom:10px;">Joystick Control</div>
       <label class="atem-toggle-wrap">
         <input id="f-joystick-enabled" type="checkbox" />
@@ -1664,6 +1664,7 @@
     captureOutput: 'webcam',
     activeCamAux: 'sdi1',
     positions: {},
+    joystick: normalizeJoystickSettings(),
     // Runtime ATEM AUX sources (not persisted, updated via SSE)
     aux1Source: 0,
     aux2Source: 0,
@@ -1735,6 +1736,25 @@
     return ['sdi1', 'sdi2', 'sdi3', 'sdi4'].includes(value) ? value : 'sdi1';
   }
 
+  function normalizeJoystickSettings(value) {
+    const defaults = {
+      enabled: false,
+      model: 'logitech-extreme-3d',
+      deadzone: 0.2,
+      sensitivity: { pan: 1.0, tilt: 1.0, zoom: 0.5 },
+      axisMap: { pan: 0, tilt: 1, zoom: 2 },
+      buttonMap: { preset1: 0, preset2: 1, preset3: 2, preset4: 3 },
+    };
+    const joystick = value && typeof value === 'object' ? value : {};
+    return {
+      ...defaults,
+      ...joystick,
+      sensitivity: { ...defaults.sensitivity, ...(joystick.sensitivity || {}) },
+      axisMap: { ...defaults.axisMap, ...(joystick.axisMap || {}) },
+      buttonMap: { ...defaults.buttonMap, ...(joystick.buttonMap || {}) },
+    };
+  }
+
   // ── Server persistence ────────────────────────────────────────────────────
   let saveTimer = null;
 
@@ -1770,6 +1790,7 @@
         if (s.captureOutput) state.captureOutput = normalizeCaptureOutput(s.captureOutput);
         if (s.activeCamAux) state.activeCamAux = normalizeActiveCamAux(s.activeCamAux);
         if (s.positions) state.positions = { ...s.positions };
+        if (s.joystick) state.joystick = normalizeJoystickSettings(s.joystick);
       }
     } catch (_) {}
   }
@@ -3243,8 +3264,7 @@
   elGspFill.addEventListener('change', saveGridSettings);
 
   function loadJoystickSettings() {
-    if (!state.joystick) return;
-    const js = state.joystick;
+    const js = state.joystick = normalizeJoystickSettings(state.joystick);
     if (elJoystickEnabled) elJoystickEnabled.checked = !!js.enabled;
     if (elJoystickDeadzone) {
       elJoystickDeadzone.value = (js.deadzone || 0.2).toFixed(2);
@@ -3266,18 +3286,27 @@
   }
 
   function saveJoystickSettings() {
-    if (!state.joystick) state.joystick = {};
-    const wasEnabled = !!state.joystick.enabled;
-    state.joystick.enabled = elJoystickEnabled?.checked || false;
-    state.joystick.deadzone = parseFloat(elJoystickDeadzone?.value || 0.2);
-    if (!state.joystick.sensitivity) state.joystick.sensitivity = {};
-    state.joystick.sensitivity.pan = parseFloat(elJoystickPanSens?.value || 1.0);
-    state.joystick.sensitivity.tilt = parseFloat(elJoystickTiltSens?.value || 1.0);
-    state.joystick.sensitivity.zoom = parseFloat(elJoystickZoomSens?.value || 0.5);
+    const prev = normalizeJoystickSettings(state.joystick);
+    const wasEnabled = !!prev.enabled;
+    state.joystick = normalizeJoystickSettings({
+      ...prev,
+      enabled: elJoystickEnabled?.checked || false,
+      deadzone: parseFloat(elJoystickDeadzone?.value || 0.2),
+      sensitivity: {
+        ...prev.sensitivity,
+        pan: parseFloat(elJoystickPanSens?.value || 1.0),
+        tilt: parseFloat(elJoystickTiltSens?.value || 1.0),
+        zoom: parseFloat(elJoystickZoomSens?.value || 0.5),
+      },
+    });
 
-    if (wasEnabled && !state.joystick.enabled && gamepadAnimationFrame) {
-      cancelAnimationFrame(gamepadAnimationFrame);
-      gamepadAnimationFrame = null;
+    if (wasEnabled && !state.joystick.enabled) {
+      if (gamepadAnimationFrame) {
+        cancelAnimationFrame(gamepadAnimationFrame);
+        gamepadAnimationFrame = null;
+      }
+      gamepadState = { pan: 0, tilt: 0, zoom: 0 };
+      sendPtzDriveCommand(0, 0, 0);
     } else if (!wasEnabled && state.joystick.enabled) {
       const connectedGamepads = typeof navigator !== 'undefined' && navigator.getGamepads
         ? Array.from(navigator.getGamepads()).filter(Boolean)

--- a/server.py
+++ b/server.py
@@ -939,6 +939,107 @@ def send_visca_preset_recall(
         sock.close()
 
 
+def send_visca_command(
+    ip: str, port: int, command: bytes, camera_address: int = 1, timeout_s: float = 0.5
+) -> tuple[bool, str]:
+    global _sequence_number
+    camera_byte = 0x80 | (camera_address & 0x07)
+    expected_reply_byte = ((camera_address + 8) << 4) & 0xF0
+    visca_payload = bytes([camera_byte]) + command + b"\xFF"
+    with _seq_lock:
+        seq = _sequence_number
+        _sequence_number = (_sequence_number + 1) & 0xFFFFFFFF
+    header = struct.pack(">HHI", 0x0100, len(visca_payload), seq)
+    packet = header + visca_payload
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout_s)
+    try:
+        sock.sendto(packet, (ip, port))
+        deadline = time.monotonic() + timeout_s
+        ack_payload = None
+        completion_payload = None
+        raw_payloads = []
+        responder_note = None
+
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            sock.settimeout(remaining)
+            try:
+                response, _ = sock.recvfrom(1024)
+            except socket.timeout:
+                break
+
+            payload = response[8:] if len(response) >= 8 else response
+            if len(payload) < 3 or payload[-1] != 0xFF:
+                continue
+            raw_payloads.append(payload.hex())
+            if payload[0] != expected_reply_byte and responder_note is None:
+                responder_note = (
+                    f"unexpected responder 0x{payload[0]:02x} "
+                    f"(expected 0x{expected_reply_byte:02x})"
+                )
+
+            code = payload[1]
+            if code == 0x41:
+                ack_payload = payload
+            elif code == 0x51:
+                completion_payload = payload
+                break
+            elif code & 0xF0 == 0x60:
+                return False, f"VISCA error {payload.hex()}"
+
+        suffix = f" [{responder_note}]" if responder_note else ""
+        if completion_payload and ack_payload:
+            return (
+                True,
+                f"ACK {ack_payload.hex()} • Completion {completion_payload.hex()}{suffix}",
+            )
+        if completion_payload:
+            return True, f"Completion {completion_payload.hex()}{suffix}"
+        if ack_payload:
+            return True, f"ACK {ack_payload.hex()} (no completion received){suffix}"
+        if raw_payloads:
+            return (
+                True,
+                f"Command sent (unparsed VISCA response: {' | '.join(raw_payloads)})",
+            )
+        return True, "Command sent (no VISCA response received)"
+    except OSError as exc:
+        return False, str(exc)
+    finally:
+        sock.close()
+
+
+def send_visca_pan_tilt_drive(
+    ip: str,
+    port: int,
+    pan_speed: int,
+    tilt_speed: int,
+    pan_dir: int,
+    tilt_dir: int,
+    camera_address: int = 1,
+) -> tuple[bool, str]:
+    pan_speed = max(1, min(0x18, int(pan_speed or 1)))
+    tilt_speed = max(1, min(0x18, int(tilt_speed or 1)))
+    command = bytes([0x01, 0x06, 0x01, pan_speed, tilt_speed, pan_dir, tilt_dir])
+    return send_visca_command(ip, port, command, camera_address=camera_address)
+
+
+def send_visca_zoom_drive(
+    ip: str, port: int, zoom_value: float, camera_address: int = 1
+) -> tuple[bool, str]:
+    zoom_abs = min(1.0, abs(float(zoom_value or 0.0)))
+    zoom_speed = max(0, min(7, int(round(zoom_abs * 7))))
+    if zoom_speed <= 0:
+        zoom_cmd = 0x00
+    else:
+        zoom_cmd = 0x20 | zoom_speed if zoom_value > 0 else 0x30 | zoom_speed
+    command = bytes([0x01, 0x04, 0x07, zoom_cmd])
+    return send_visca_command(ip, port, command, camera_address=camera_address)
+
+
 def inquire_visca_pan_tilt_position(
     ip: str, port: int, camera_address: int = 1
 ) -> tuple[bool, dict | str]:
@@ -1295,6 +1396,22 @@ def _require_atem_enabled_and_connected() -> tuple[bool, dict | None]:
     return True, None
 
 
+def _live_movement_block_reason(settings: dict, cam_idx: int, cfg: dict) -> str | None:
+    if not settings.get("liveMode") or not settings.get("lockLiveMode"):
+        return None
+    if not settings.get("atem", {}).get("enabled"):
+        return None
+    atem_input = int(cfg.get("atemInput", 0) or 0)
+    if atem_input <= 0:
+        return None
+    atem = _get_atem()
+    if not atem.get("connected"):
+        return "ATEM is disconnected. Live lock stays enabled until program state can be confirmed."
+    if int(atem.get("program", 0) or 0) == atem_input:
+        return "LIVE camera is locked. Switch cameras or unlock Live mode before moving."
+    return None
+
+
 def _require_camera(
     settings: dict, cam_idx: int
 ) -> tuple[bool, dict | None, dict | None]:
@@ -1392,6 +1509,8 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_recall()
         elif path == "/atem/cut":
             self._handle_atem_cut()
+        elif path == "/api/ptz/drive":
+            self._handle_ptz_drive()
         elif path == "/api/atem/preview":
             self._handle_atem_preview_post()
         elif path == "/api/atem/aux-route":
@@ -1443,6 +1562,76 @@ class Handler(BaseHTTPRequestHandler):
             self._json(200, {"ok": True})
         except Exception as e:
             self._json(400, {"ok": False, "error": str(e)})
+
+    def _handle_ptz_drive(self):
+        body = self._read_body()
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self._json(400, {"ok": False, "error": "Invalid JSON"})
+            return
+
+        try:
+            cam_idx = int(data.get("camIdx", -1))
+            pan = max(-1.0, min(1.0, float(data.get("pan", 0) or 0)))
+            tilt = max(-1.0, min(1.0, float(data.get("tilt", 0) or 0)))
+            zoom = max(-1.0, min(1.0, float(data.get("zoom", 0) or 0)))
+        except (TypeError, ValueError):
+            self._json(400, {"ok": False, "error": "Invalid PTZ command payload"})
+            return
+
+        settings = load_settings()
+        cameras = settings.get("cameras") or []
+        if cam_idx < 0 or cam_idx >= len(cameras):
+            self._json(404, {"ok": False, "error": "Camera not found"})
+            return
+
+        cfg = cameras[cam_idx] or {}
+        ip = str(cfg.get("ip", "")).strip()
+        if not ip:
+            self._json(400, {"ok": False, "error": "Camera IP is required"})
+            return
+
+        block_reason = _live_movement_block_reason(settings, cam_idx, cfg)
+        if block_reason:
+            self._json(409, {"ok": False, "error": block_reason})
+            return
+
+        port = int(cfg.get("port", 52381) or 52381)
+        visca_addr = int(cfg.get("viscaAddr", 1) or 1)
+        deadzone = 0.05
+        pan_mag = abs(pan)
+        tilt_mag = abs(tilt)
+        pan_dir = 0x03 if pan_mag < deadzone else (0x01 if pan < 0 else 0x02)
+        tilt_dir = 0x03 if tilt_mag < deadzone else (0x01 if tilt > 0 else 0x02)
+        pan_speed = 1 if pan_dir == 0x03 else max(1, min(0x18, int(round(pan_mag * 0x18))))
+        tilt_speed = 1 if tilt_dir == 0x03 else max(1, min(0x18, int(round(tilt_mag * 0x18))))
+
+        pt_ok, pt_message = send_visca_pan_tilt_drive(
+            ip,
+            port,
+            pan_speed,
+            tilt_speed,
+            pan_dir,
+            tilt_dir,
+            camera_address=visca_addr,
+        )
+        zoom_ok, zoom_message = send_visca_zoom_drive(
+            ip, port, zoom, camera_address=visca_addr
+        )
+        ok = pt_ok and zoom_ok
+        self._json(
+            200 if ok else 502,
+            {
+                "ok": ok,
+                "camIdx": cam_idx,
+                "pan": pan,
+                "tilt": tilt,
+                "zoom": zoom,
+                "panTiltMessage": pt_message,
+                "zoomMessage": zoom_message,
+            },
+        )
 
     def _handle_atem_cut(self):
         """

--- a/server.py
+++ b/server.py
@@ -966,7 +966,7 @@ def send_visca_command(
     global _sequence_number
     camera_byte = 0x80 | (camera_address & 0x07)
     expected_reply_byte = ((camera_address + 8) << 4) & 0xF0
-    visca_payload = bytes([camera_byte]) + command + b"\xFF"
+    visca_payload = bytes([camera_byte]) + command + b"\xff"
     with _seq_lock:
         seq = _sequence_number
         _sequence_number = (_sequence_number + 1) & 0xFFFFFFFF
@@ -1429,7 +1429,9 @@ def _live_movement_block_reason(settings: dict, cam_idx: int, cfg: dict) -> str 
     if not atem.get("connected"):
         return "ATEM is disconnected. Live lock stays enabled until program state can be confirmed."
     if int(atem.get("program", 0) or 0) == atem_input:
-        return "LIVE camera is locked. Switch cameras or unlock Live mode before moving."
+        return (
+            "LIVE camera is locked. Switch cameras or unlock Live mode before moving."
+        )
     return None
 
 
@@ -1625,8 +1627,12 @@ class Handler(BaseHTTPRequestHandler):
         tilt_mag = abs(tilt)
         pan_dir = 0x03 if pan_mag < deadzone else (0x01 if pan < 0 else 0x02)
         tilt_dir = 0x03 if tilt_mag < deadzone else (0x01 if tilt > 0 else 0x02)
-        pan_speed = 1 if pan_dir == 0x03 else max(1, min(0x18, int(round(pan_mag * 0x18))))
-        tilt_speed = 1 if tilt_dir == 0x03 else max(1, min(0x18, int(round(tilt_mag * 0x18))))
+        pan_speed = (
+            1 if pan_dir == 0x03 else max(1, min(0x18, int(round(pan_mag * 0x18))))
+        )
+        tilt_speed = (
+            1 if tilt_dir == 0x03 else max(1, min(0x18, int(round(tilt_mag * 0x18))))
+        )
 
         pt_ok, pt_message = send_visca_pan_tilt_drive(
             ip,

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -95,6 +95,27 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("updateCaptureModeVisibility();", self.html)
         self.assertIn("updateCameraStatusHints();", self.html)
 
+    def test_joystick_state_is_normalized_and_visible(self):
+        self.assertIn(
+            'id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem"',
+            self.html,
+        )
+        self.assertNotIn(
+            'id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem" style="display:none;"',
+            self.html,
+        )
+        self.assertIn("function normalizeJoystickSettings(value)", self.html)
+        self.assertIn("joystick: normalizeJoystickSettings(),", self.html)
+        self.assertIn(
+            "if (s.joystick) state.joystick = normalizeJoystickSettings(s.joystick);",
+            self.html,
+        )
+        self.assertIn(
+            "const js = state.joystick = normalizeJoystickSettings(state.joystick);",
+            self.html,
+        )
+        self.assertIn("state.joystick = normalizeJoystickSettings({", self.html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

PR #74 merged before later DEV updates landed, so `default` is missing the final joystick/gamepad fixes and the merged virtual joystick work from PR #71.

This follow-up PR brings `default` up to the current `DEV` state, including:
- virtual joystick PTZ drive support with live-lock guardrails
- gamepad PTZ input routed through the same safe move path
- joystick settings visibility, hydration, and persistence fixes
- frontend contract coverage for the joystick state regressions

## Verification

- `python3 -m py_compile server.py`
- `ruff check server.py`
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual touch joystick for pan/tilt/zoom with touch-device detection, persisted visibility, and automatic start/stop of movement on touch end.
  * Improved gamepad behavior: continuous PTZ commands while connected and explicit stop on disconnect.
  * New network PTZ drive endpoint enabling remote pan/tilt/zoom commands with Live Mode movement blocking when appropriate.

* **Bug Fixes**
  * Restored visibility and configurability of joystick settings in the Settings panel.

* **Tests**
  * Added test validating joystick visibility and state normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->