### PR TITLE
Fix: Require position recording before saving preset images

### DIFF
--- a/server.py
+++ b/server.py
@@ -1984,9 +1984,24 @@ class Handler(BaseHTTPRequestHandler):
             return
         _ensure_dirs()
         fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")
-        with open(fpath, "wb") as f:
-            f.write(data)
-        write_settings(settings)
+        try:
+            with open(fpath, "wb") as f:
+                f.write(data)
+            write_settings(settings)
+        except Exception as e:
+            try:
+                if os.path.exists(fpath):
+                    os.remove(fpath)
+            except Exception:
+                pass
+            self._json(
+                500,
+                {
+                    "ok": False,
+                    "error": f"failed to persist preset image: {e}",
+                },
+            )
+            return
         self._json(200, {"ok": True, "position": position})
 
     def _capture_image(self, cam: int, preset: int):
@@ -2081,9 +2096,24 @@ class Handler(BaseHTTPRequestHandler):
                 return
             _ensure_dirs()
             fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")
-            with open(fpath, "wb") as f:
-                f.write(jpeg)
-            write_settings(settings)
+            try:
+                with open(fpath, "wb") as f:
+                    f.write(jpeg)
+                write_settings(settings)
+            except Exception as persist_error:
+                try:
+                    if os.path.exists(fpath):
+                        os.remove(fpath)
+                except Exception:
+                    pass
+                self._json(
+                    500,
+                    {
+                        "ok": False,
+                        "error": f"failed to persist captured image: {persist_error}",
+                    },
+                )
+                return
             self._json(200, {"ok": True, "position": position})
         except Exception as e:
             self._json(500, {"ok": False, "error": str(e)})

--- a/server.py
+++ b/server.py
@@ -1970,15 +1970,23 @@ class Handler(BaseHTTPRequestHandler):
         self._json(200, {"ok": True, **pos})
 
     def _post_image(self, cam: int, preset: int):
-        _ensure_dirs()
         data = self._read_body()
+        settings = load_settings()
+        position = _try_record_position(settings, cam, preset)
+        if position is None:
+            self._json(
+                400,
+                {
+                    "ok": False,
+                    "error": "could not record camera position — cannot save preset image without position data",
+                },
+            )
+            return
+        _ensure_dirs()
         fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")
         with open(fpath, "wb") as f:
             f.write(data)
-        settings = load_settings()
-        position = _try_record_position(settings, cam, preset)
-        if position is not None:
-            write_settings(settings)
+        write_settings(settings)
         self._json(200, {"ok": True, "position": position})
 
     def _capture_image(self, cam: int, preset: int):
@@ -2060,14 +2068,22 @@ class Handler(BaseHTTPRequestHandler):
                     },
                 )
                 return
+            settings = load_settings()
+            position = _try_record_position(settings, cam, preset)
+            if position is None:
+                self._json(
+                    400,
+                    {
+                        "ok": False,
+                        "error": "could not record camera position — cannot save preset image without position data",
+                    },
+                )
+                return
             _ensure_dirs()
             fpath = os.path.join(IMAGES_DIR, f"{cam}_{preset}.jpg")
             with open(fpath, "wb") as f:
                 f.write(jpeg)
-            settings = load_settings()
-            position = _try_record_position(settings, cam, preset)
-            if position is not None:
-                write_settings(settings)
+            write_settings(settings)
             self._json(200, {"ok": True, "position": position})
         except Exception as e:
             self._json(500, {"ok": False, "error": str(e)})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -931,9 +931,15 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(status, 404)
 
     def test_image_upload_retrieve_delete(self):
+        server.write_settings(self._settings_with_camera_ip())
         fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 20
 
-        status, body = self.srv.post("/api/image/0/7", fake_jpeg, "image/jpeg")
+        with patch(
+            "server.inquire_visca_absolute_position",
+            return_value=(True, self._MOCK_POSITION),
+        ):
+            status, body = self.srv.post("/api/image/0/7", fake_jpeg, "image/jpeg")
+
         self.assertEqual(status, 200)
         self.assertTrue(json.loads(body)["ok"])
 
@@ -948,11 +954,18 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(status, 404)
 
     def test_image_response_is_cacheable(self):
+        server.write_settings(self._settings_with_camera_ip())
         fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 20
-        status, _ = self.srv.post("/api/image/1/3", fake_jpeg, "image/jpeg")
+
+        with patch(
+            "server.inquire_visca_absolute_position",
+            return_value=(True, self._MOCK_POSITION),
+        ):
+            status, _ = self.srv.post("/api/image/0/3", fake_jpeg, "image/jpeg")
+
         self.assertEqual(status, 200)
 
-        status, headers, data = self.srv.get_with_headers("/api/image/1/3")
+        status, headers, data = self.srv.get_with_headers("/api/image/0/3")
         self.assertEqual(status, 200)
         self.assertEqual(data, fake_jpeg)
         self.assertEqual(
@@ -1056,13 +1069,13 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(saved["positions"]["0:3"]["pan_hex"], "1234")
 
     def test_post_image_position_null_when_no_camera_ip(self):
-        # DEFAULT_SETTINGS cameras have ip=""
+        # DEFAULT_SETTINGS cameras have ip="" — position recording now required before saving image
         fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 20
         status, body = self.srv.post("/api/image/0/3", fake_jpeg, "image/jpeg")
-        self.assertEqual(status, 200)
+        self.assertEqual(status, 400)
         data = json.loads(body)
-        self.assertTrue(data["ok"])
-        self.assertIsNone(data["position"])
+        self.assertFalse(data["ok"])
+        self.assertIn("could not record camera position", data.get("error", "").lower())
 
     def test_post_image_position_null_when_inquiry_fails(self):
         server.write_settings(self._settings_with_camera_ip())
@@ -1074,10 +1087,10 @@ class TestHTTPRoutes(unittest.TestCase):
         ):
             status, body = self.srv.post("/api/image/0/3", fake_jpeg, "image/jpeg")
 
-        self.assertEqual(status, 200)
+        self.assertEqual(status, 400)
         data = json.loads(body)
-        self.assertTrue(data["ok"])
-        self.assertIsNone(data["position"])
+        self.assertFalse(data["ok"])
+        self.assertIn("could not record camera position", data.get("error", "").lower())
 
     def test_delete_image_clears_stored_position(self):
         server.write_settings(self._settings_with_camera_ip())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -721,6 +721,13 @@ class TestHTTPRoutes(unittest.TestCase):
         settings = dict(server.DEFAULT_SETTINGS)
         settings["positions"] = {}
         server.write_settings(settings)
+        # Clean up any leftover image files from previous tests
+        import glob
+        for img_file in glob.glob(os.path.join(server.IMAGES_DIR, "*.jpg")):
+            try:
+                os.remove(img_file)
+            except Exception:
+                pass
 
     # ── static & settings ──────────────────────────────────────────────────────
 
@@ -1076,6 +1083,9 @@ class TestHTTPRoutes(unittest.TestCase):
         data = json.loads(body)
         self.assertFalse(data["ok"])
         self.assertIn("could not record camera position", data.get("error", "").lower())
+        # Verify image file was not written
+        status_img, _ = self.srv.get("/api/image/0/3")
+        self.assertEqual(status_img, 404)
 
     def test_post_image_position_null_when_inquiry_fails(self):
         server.write_settings(self._settings_with_camera_ip())
@@ -1091,6 +1101,9 @@ class TestHTTPRoutes(unittest.TestCase):
         data = json.loads(body)
         self.assertFalse(data["ok"])
         self.assertIn("could not record camera position", data.get("error", "").lower())
+        # Verify image file was not written
+        status_img, _ = self.srv.get("/api/image/0/3")
+        self.assertEqual(status_img, 404)
 
     def test_delete_image_clears_stored_position(self):
         server.write_settings(self._settings_with_camera_ip())


### PR DESCRIPTION
## Summary
Fixed a critical bug where preset images could be saved without corresponding position data, violating CLAUDE.md's live-safety requirement that "scan or capture flows should not silently generate bad preset images."

## Problem
Both the image upload (`POST /api/image/{cam}/{preset}`) and capture endpoints (`POST /api/capture/{cam}/{preset}`) were saving images to disk **before** attempting to record the camera's pan/tilt/zoom position. If position recording failed (e.g., no camera IP configured, VISCA inquiry timeout), the image would still be saved and the response would report success with `{"ok": true, "position": null}`.

This created orphaned image files without position records, which operators might assume correctly represent the preset configuration when they actually represent an unknown or invalid state.

## Solution
- Moved position recording to happen **before** image save in both handlers
- Returns HTTP 400 with a clear error message if position cannot be recorded
- Image is only saved to disk after position data is successfully recorded
- Updated tests to properly configure camera settings and mock position inquiries

## Testing
- All 153 unit tests pass
- Code formatting and linting pass
- Python compilation succeeds

The fix ensures every saved preset image has a corresponding position record, protecting operators from the confusion of images without known camera positions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJeNKiCdd3fNm9YtoQAnyK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads now require successful camera position recording before saving files. Uploads fail with HTTP 400 and a clear error when position cannot be recorded, preventing incomplete or orphaned image files.
* **Tests**
  * Integration tests updated to validate the new upload behavior and to ensure test runs clean up leftover image files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->