### PR TITLE
Fix: Make manual SNAP always update button for active camera

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4218,16 +4218,12 @@
   }
 
   async function capturePreset(n) {
-    const cam = resolveCaptureCamera();
+    const cam = state.activeCam;
     const ok = await captureFrame(cam, n);
     if (ok) {
       clearSnapNeeded(cam, n);
       bumpImageVersion(cam, n);
-      if (cam === state.activeCam) {
-        refreshPresetBtn(n, cam);
-      } else {
-        setStatus('success', `Captured preset ${n} (camera ${cam + 1})`);
-      }
+      refreshPresetBtn(n, cam);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes issue #79: Manual SNAP button was not reliably updating the preset button display.

## Problem

When a user clicked the SNAP button to capture a preset image, the button sometimes didn't update to show the newly captured image. The issue occurred when `captureSource` was set to 'preview' or 'program':

- The preset button grid displays presets for `state.activeCam`
- `capturePreset()` was using `resolveCaptureCamera()` to determine which camera to capture from
- If the resolved camera differed from the active camera, the image was captured to that different camera
- The button was not refreshed because the condition `if (cam === state.activeCam)` failed

## Solution

Changed `capturePreset()` to always capture for `state.activeCam`. This makes sense because:
- The button being clicked is part of the active camera's grid
- The user expects the image to be saved for that preset on the active camera
- The `captureFrame()` function already resolves where to get the image data from (USB device, URL stream, or webcam) based on the camera's configuration

## Changes

- Removed `resolveCaptureCamera()` call from `capturePreset()`
- Always use `state.activeCam` when capturing from the SNAP button
- Always call `refreshPresetBtn()` to update the button display

## Testing

- ✅ All 8 frontend contract tests pass
- ✅ All 153 unit/integration tests pass
- ✅ Linting and syntax checks pass

https://claude.ai/code/session_01QSRUQXstjrJYp8ubP6Hcis

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSRUQXstjrJYp8ubP6Hcis)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced preset capture functionality to improve reliability and consistency. Preset button states now always update correctly after successful capture operations, eliminating previous conditional behavior that sometimes resulted in inconsistent user interface responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->