### PR TITLE
Show SNAP button when camera position drifts from preset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2692,6 +2692,7 @@
         return false;
       }
       lastVirtualPtz = next;
+      checkAllPresetsForDrift();
       return true;
     } catch (err) {
       setStatus('error', `PTZ move failed: ${err.message || err}`);
@@ -4007,6 +4008,13 @@
     } catch (_) {}
   }
 
+  async function checkAllPresetsForDrift(camIdx = state.activeCam) {
+    const presets = presetNumbers();
+    for (const preset of presets) {
+      checkPositionAfterRecall(preset, camIdx);
+    }
+  }
+
   function presetNumbers() {
     const nums = [];
     const range = getDevicePresetRange();
@@ -4029,6 +4037,7 @@
     }
     nums.forEach(n => refreshPresetBtn(n, state.activeCam));
     updatePresetGridBusState();
+    checkAllPresetsForDrift();
   }
 
   function updateFillGridMetrics() {


### PR DESCRIPTION
## Summary
Continuously detect when camera position has drifted from saved preset positions and highlight the SNAP button with a pulsing indicator. This works for both scenarios:
1. User recalled a preset and manually adjusted the shot
2. User manually choosing to update a preset without recalling first

## Changes
- Add `checkAllPresetsForDrift()` to check all visible presets against current camera position
- Call after manual PTZ movement completes
- Call when switching between cameras

## Result
SNAP button now displays pulsing "needs-snap" animation when camera is not at saved preset position, providing clear visual feedback to update stale images and preventing silent capture of wrong positions in live production.

## Testing
- Unit tests: all 153 tests pass
- Server: starts and serves successfully
- JavaScript: no syntax errors, new function integrated correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2b61wXBFGnNPsBwvosCAU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset accuracy verification by automatically checking all configured presets for drift after camera movements and grid refreshes to ensure reliable preset recall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->