### PR TITLE
Fix: Only track SNAP indicator for the recalled preset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2692,7 +2692,7 @@
         return false;
       }
       lastVirtualPtz = next;
-      checkAllPresetsForDrift();
+      checkRecalledPresetForDrift();
       return true;
     } catch (err) {
       setStatus('error', `PTZ move failed: ${err.message || err}`);
@@ -3979,6 +3979,9 @@
     if (btn) btn.classList.remove('needs-snap');
   }
 
+  let lastRecalledPreset = null;
+  let lastRecalledCam = null;
+
   async function checkPositionAfterRecall(preset, camIdx) {
     const cam = state.cameras[camIdx];
     if (!(cam && cam.ip)) return;
@@ -4008,11 +4011,9 @@
     } catch (_) {}
   }
 
-  async function checkAllPresetsForDrift(camIdx = state.activeCam) {
-    const presets = presetNumbers();
-    for (const preset of presets) {
-      checkPositionAfterRecall(preset, camIdx);
-    }
+  async function checkRecalledPresetForDrift(camIdx = state.activeCam) {
+    if (lastRecalledPreset === null || lastRecalledCam !== camIdx) return;
+    checkPositionAfterRecall(lastRecalledPreset, camIdx);
   }
 
   function presetNumbers() {
@@ -4037,7 +4038,8 @@
     }
     nums.forEach(n => refreshPresetBtn(n, state.activeCam));
     updatePresetGridBusState();
-    checkAllPresetsForDrift();
+    lastRecalledPreset = null;
+    lastRecalledCam = null;
   }
 
   function updateFillGridMetrics() {
@@ -4467,6 +4469,8 @@
       );
       setStatus('success', msg);
       scheduleAutoCut(n, autoCutPlan, autoCutTrigger || 'settled', recallElapsedMs);
+      lastRecalledPreset = n;
+      lastRecalledCam = recallCamIdx;
       if (data.settled) checkPositionAfterRecall(n, recallCamIdx);
     } else {
       const recallElapsedMs = Math.max(


### PR DESCRIPTION
## Problem
The previous implementation was checking ALL presets against the current camera position, causing every SNAP button to flash as needing update. This is incorrect because **we have no way to know if a preset's position changed without first recalling it**.

## Solution
Only track the preset that was **most recently recalled**:
- `lastRecalledPreset` tracks which preset was recalled
- After camera movement (PTZ drive), only check that specific preset
- Clear tracking when switching cameras
- SNAP indicator only shows when we have a reference point

## Behavior
User recalls preset → adjusts shot → **only that preset's SNAP button highlights**, providing clear indication that image needs updating.

## Testing
- All 153 unit tests pass
- Server runs successfully
- Tested locally with corrected logic

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2b61wXBFGnNPsBwvosCAU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized snap-on-drift detection to focus on recently recalled presets rather than scanning all presets, improving system responsiveness and reducing processing overhead during PTZ camera operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->