### PR TITLE
[codex] improve gamepad diagnostics and live preset scan safety

### DIFF
--- a/GAMEPAD_SETUP.md
+++ b/GAMEPAD_SETUP.md
@@ -12,7 +12,7 @@ The main issue is that **8BitDo controllers have multiple modes** that change bu
 3. **Check "Show Debug Info"**
 4. Look at the bottom section - you should see something like:
 
-```
+```text
 Gamepad: 8BitDo Zero 2 (16 btns, 6 axes)
 ```
 
@@ -76,7 +76,7 @@ Once in DirectInput mode:
 
 When enabled, you'll see:
 
-```
+```text
 Pan: 1.000    Tilt: 0.000  [● glowing indicator]
 Zoom: 0.500
 
@@ -134,7 +134,7 @@ Since you're watching remotely:
 
 ## Quick Reference
 
-```
+```text
 8BitDo Zero 2 Modes:
 ┌─────────────────────────────────────────────────┐
 │ Hold X + Start for 3 seconds                    │

--- a/GAMEPAD_SETUP.md
+++ b/GAMEPAD_SETUP.md
@@ -1,0 +1,164 @@
+# 8BitDo Zero 2 Gamepad Setup Guide
+
+## Quick Summary
+
+The main issue is that **8BitDo controllers have multiple modes** that change button mappings. The app expects **DirectInput/D-Input mode** with d-pad mapped to buttons 12-15.
+
+## Step 1: Identify Your Gamepad Mode
+
+### Open Debug Info
+1. Go to Settings (⚙️ icon)
+2. Scroll to **"Joystick Control"**
+3. **Check "Show Debug Info"**
+4. Look at the bottom section - you should see something like:
+
+```
+Gamepad: 8BitDo Zero 2 (16 btns, 6 axes)
+```
+
+### Check Button Count
+
+| Button Count | Mode | Status |
+|---|---|---|
+| **16 buttons** | ✅ **DirectInput (D-Input)** | **Correct - Use "8BitDo Zero 2" profile** |
+| 10 buttons | ❌ XInput | Wrong - Switch controller mode |
+| 17 buttons | ❌ Switch mode | Wrong - Switch controller mode |
+
+## Step 2: Switch to Correct Mode (if needed)
+
+### 8BitDo Zero 2 Mode Switch
+
+The 8BitDo Zero 2 uses **button combinations** to switch modes:
+
+1. **Power on** the controller
+2. **Hold X + Start** for ~3 seconds until LED flashes
+3. Check the LED color pattern:
+   - 🔴 Red flash = DirectInput (D-Input) ✅
+   - 🔵 Blue flash = XInput
+   - 🟢 Green flash = Switch mode
+
+### Details for Different Modes
+
+**DirectInput (D-Input)** - What you want:
+- LED: Solid blue when connected
+- Buttons: 16 total
+- D-Pad: Buttons 12, 13, 14, 15
+- Best for: This app
+
+**XInput** - Don't use for d-pad:
+- LED: Different color pattern
+- Buttons: 10 total  
+- D-Pad: Uses HAT switch (not supported by this app)
+
+## Step 3: Verify D-Pad Buttons
+
+Once in DirectInput mode:
+
+1. Open Settings and enable **Show Debug Info**
+2. Press d-pad buttons one at a time:
+   - Press **Up** → should show `[12]`
+   - Press **Right** → should show `[15]`
+   - Press **Down** → should show `[13]`
+   - Press **Left** → should show `[14]`
+
+3. You should see in the "Pressed buttons" line: `[12]`, `[13]`, `[14]`, or `[15]`
+
+**If you see different numbers or nothing**, the gamepad is in the wrong mode.
+
+## Step 4: Configure in App
+
+1. **Enable Joystick**: Check the checkbox
+2. **Device Profile**: Select **"8BitDo Zero 2 (D-Pad)"**
+3. **Sensitivity**: Adjust as needed (start with 1.0x for pan/tilt)
+4. The debug panel should show a suggestion if mode is wrong
+
+## Understanding Debug Output
+
+When enabled, you'll see:
+
+```
+Pan: 1.000    Tilt: 0.000  [● glowing indicator]
+Zoom: 0.500
+
+Gamepad: 8BitDo Zero 2 (16 btns, 6 axes)
+Pressed buttons: [15]
+```
+
+### What Each Line Means
+
+- **Pan/Tilt/Zoom**: Current movement values (0 = stopped, 1 = full speed)
+- **Indicator glow**: Shows when input is being registered
+- **Gamepad line**: Device name and capabilities. If you see a warning like `"Try mode: 8bitdo-zero2"`, follow that suggestion
+- **Pressed buttons**: Which physical buttons are being pressed (should be 12, 13, 14, or 15 for d-pad)
+
+## Troubleshooting
+
+### D-Pad Not Responding
+
+**Symptoms**: Pressing d-pad does nothing
+
+**Check**:
+1. Is "Enable Joystick" checked?
+2. Is debug "Pressed buttons" showing numbers when you press d-pad?
+   - **No** → Wrong gamepad mode. Switch to DirectInput.
+   - **Yes** → Check if buttons are 12-15. If not, check Profile setting.
+
+### Camera Moving But Not Stopping
+
+**Symptoms**: Camera keeps moving after releasing d-pad
+
+**Check**:
+1. Is the indicator still glowing after releasing?
+   - **Yes** → D-pad button stuck or not releasing properly
+   - **No** → VISCA stop command was sent. This might be a network delay.
+
+2. Check browser console (`F12` → Console):
+   - Should see `[GAMEPAD] Sending STOP command` when you release buttons
+   - Should see button indices `[12]`, `[13]`, `[14]`, `[15]` for d-pad
+
+### Inconsistent Response
+
+**Symptoms**: Sometimes works, sometimes doesn't
+
+**Likely cause**: Gamepad switching between modes
+- Check gamepad LED color - should be solid when connected
+- Try the mode switch combination again (X + Start)
+- Look at debug output - does "button count" change?
+
+### Visual Delay with Remote View
+
+Since you're watching remotely:
+- The **indicator glow** confirms your input was sent immediately
+- Camera movement delay is from network lag, not the app
+- VISCA commands are being sent correctly if you see the indicator
+
+## Quick Reference
+
+```
+8BitDo Zero 2 Modes:
+┌─────────────────────────────────────────────────┐
+│ Hold X + Start for 3 seconds                    │
+│ 🔴 Red flash   = DirectInput (D-Input) ✅       │
+│ 🔵 Blue flash  = XInput ❌                      │
+│ 🟢 Green flash = Switch ❌                      │
+└─────────────────────────────────────────────────┘
+
+DirectInput Button Mapping:
+Up    = Button 12
+Right = Button 15  
+Down  = Button 13
+Left  = Button 14
+```
+
+## Still Having Issues?
+
+1. **Open browser console** (`F12`)
+2. **Enable debug info** in settings
+3. **Press d-pad** and watch both console and debug panel
+4. Look for:
+   - Gamepad connection message
+   - D-pad button presses showing indices
+   - STOP commands being sent
+   - Any error messages
+
+The console will help identify exactly where the breakdown is happening.

--- a/public/index.html
+++ b/public/index.html
@@ -1606,8 +1606,10 @@
         <span>Show Debug Info</span>
       </label>
       <div id="joystick-debug" style="color:var(--muted); font-size:0.8rem; margin-top:12px; line-height:1.4; font-family:monospace; display:none; padding:8px; background:var(--surf2); border-radius:4px;">
-        <div>Pan: <span id="dbg-joystick-pan">—</span></div>
-        <div>Tilt: <span id="dbg-joystick-tilt">—</span></div>
+        <div style="display:flex; justify-content:space-between; align-items:center;">
+          <div style="flex:1;">Pan: <span id="dbg-joystick-pan">—</span> Tilt: <span id="dbg-joystick-tilt">—</span></div>
+          <div id="gamepad-input-indicator" style="width:12px; height:12px; border-radius:50%; background:var(--muted); transition:all 0.1s;"></div>
+        </div>
         <div>Zoom: <span id="dbg-joystick-zoom">—</span></div>
         <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Raw axes:</div>
         <div>Ax0: <span id="dbg-joystick-ax0">—</span> Ax1: <span id="dbg-joystick-ax1">—</span> Ax2: <span id="dbg-joystick-ax2">—</span></div>
@@ -2311,6 +2313,18 @@
       const elDbgButtons = document.getElementById('dbg-joystick-buttons');
       if (elDbgButtons) {
         elDbgButtons.textContent = pressedButtons.length > 0 ? `[${pressedButtons.join(', ')}]` : 'None';
+      }
+
+      const elIndicator = document.getElementById('gamepad-input-indicator');
+      if (elIndicator) {
+        const hasInput = gamepadState.pan !== 0 || gamepadState.tilt !== 0 || gamepadState.zoom !== 0;
+        if (hasInput) {
+          elIndicator.style.background = 'var(--accent)';
+          elIndicator.style.boxShadow = '0 0 8px var(--accent)';
+        } else {
+          elIndicator.style.background = 'var(--muted)';
+          elIndicator.style.boxShadow = 'none';
+        }
       }
     } else {
       elDbgJoystickPan.textContent = '—';

--- a/public/index.html
+++ b/public/index.html
@@ -1598,8 +1598,9 @@
         5. If wrong, switch gamepad to DirectInput/D-Input mode<br/>
         <br/>
         <strong>8BitDo Zero 2 Modes:</strong><br/>
-        • <strong>D-Input</strong> ✓ (16 buttons) - Use "8BitDo Zero 2" profile<br/>
-        • X-Input (10 buttons) - Switch to D-Input mode on controller
+        • <strong>D-Input</strong> ✓ (16 buttons) - Use "8BitDo Zero 2 (D-Pad)" profile<br/>
+        • X-Input (10 buttons) - Switch to D-Input mode on controller<br/>
+        • Switch mode (17 buttons) - Switch to D-Input mode on controller
       </div>
       <label class="atem-toggle-wrap" style="margin-top:12px;">
         <input id="f-joystick-debug" type="checkbox" />
@@ -1614,7 +1615,7 @@
         <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Raw axes:</div>
         <div>Ax0: <span id="dbg-joystick-ax0">—</span> Ax1: <span id="dbg-joystick-ax1">—</span> Ax2: <span id="dbg-joystick-ax2">—</span></div>
         <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Gamepad:</div>
-        <div id="dbg-joystick-info">—</div>
+        <div id="dbg-joystick-info" style="white-space:pre-line;">—</div>
         <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Pressed buttons:</div>
         <div id="dbg-joystick-buttons" style="word-wrap:break-word;">—</div>
       </div>
@@ -3048,14 +3049,16 @@
     if (!gamepadConnected) return;
     const cmd = { pan: gamepadState.pan, tilt: -gamepadState.tilt, zoom: gamepadState.zoom };
     const isDuplicate = cmd.pan === lastVirtualPtz.pan && cmd.tilt === lastVirtualPtz.tilt && cmd.zoom === lastVirtualPtz.zoom;
-    if (cmd.pan === 0 && cmd.tilt === 0 && cmd.zoom === 0) {
-      if (!isDuplicate) {
-        console.debug('[GAMEPAD] Sending STOP command');
+    if (state.showJoystickDebug) {
+      if (cmd.pan === 0 && cmd.tilt === 0 && cmd.zoom === 0) {
+        if (!isDuplicate) {
+          console.debug('[GAMEPAD] Sending STOP command');
+        } else {
+          console.debug('[GAMEPAD] STOP already sent, deduplicating');
+        }
       } else {
-        console.debug('[GAMEPAD] STOP already sent, deduplicating');
+        console.debug('[GAMEPAD] Sending command:', cmd, isDuplicate ? '(duplicate, skipped)' : '(sent)');
       }
-    } else {
-      console.debug('[GAMEPAD] Sending command:', cmd, isDuplicate ? '(duplicate, skipped)' : '(sent)');
     }
     sendPtzDriveCommand(gamepadState.pan, -gamepadState.tilt, gamepadState.zoom);
   }

--- a/public/index.html
+++ b/public/index.html
@@ -1734,12 +1734,13 @@
     };
 
     if (id.includes('8bitdo') || id.includes('8bit do')) {
-      if (btnCount >= 16 && axCount >= 2) {
+      if (btnCount === 16 && axCount >= 2) {
         detected.suggestion = '8bitdo-zero2';
         detected.reason = 'DirectInput mode (D-Pad recommended)';
       } else if (btnCount === 10) {
-        detected.suggestion = 'logitech-extreme-3d';
-        detected.reason = 'XInput mode (needs reconfiguration)';
+        detected.reason = 'XInput mode detected — switch the controller to D-Input';
+      } else if (btnCount === 17) {
+        detected.reason = 'Switch mode detected — switch the controller to D-Input';
       } else {
         detected.reason = `Unknown mode: ${btnCount} buttons, ${axCount} axes`;
       }
@@ -2337,6 +2338,11 @@
       const elDbgButtons = document.getElementById('dbg-joystick-buttons');
       if (elDbgButtons) {
         elDbgButtons.textContent = '—';
+      }
+      const elIndicator = document.getElementById('gamepad-input-indicator');
+      if (elIndicator) {
+        elIndicator.style.background = 'var(--muted)';
+        elIndicator.style.boxShadow = 'none';
       }
     }
   }
@@ -3161,9 +3167,10 @@
       .every(idx => idx !== undefined && idx < gamepad.buttons.length);
     if (!validIndices) {
       console.warn('[D-PAD] Invalid button indices for profile:', cfg.model, dpadMap, `gamepad has ${gamepad.buttons.length} buttons`);
+      dpadState = { up: false, down: false, left: false, right: false };
+      lastDpadState = { ...dpadState };
       gamepadState.pan = 0;
       gamepadState.tilt = 0;
-      dpadState = { up: false, down: false, left: false, right: false };
       return;
     }
 
@@ -3173,16 +3180,11 @@
       left: gamepad.buttons[dpadMap.left]?.pressed || false,
       right: gamepad.buttons[dpadMap.right]?.pressed || false,
     };
-    dpadState = newState;
-
-    // Debug: Log state changes
-    if (newState.up || newState.down || newState.left || newState.right) {
-      console.debug('[D-PAD] Buttons pressed:', { up: newState.up, down: newState.down, left: newState.left, right: newState.right });
-    }
-    if ((newState.up || newState.down || newState.left || newState.right) !==
-        (lastDpadState.up || lastDpadState.down || lastDpadState.left || lastDpadState.right)) {
+    const changed = ['up', 'down', 'left', 'right'].some(key => newState[key] !== lastDpadState[key]);
+    if (state.showJoystickDebug && changed) {
       console.debug('[D-PAD] State changed:', newState);
     }
+    dpadState = newState;
     lastDpadState = newState;
 
     const deadzone = cfg.deadzone || 0.15;

--- a/public/index.html
+++ b/public/index.html
@@ -1589,6 +1589,18 @@
       <div id="joystick-status" style="color:var(--muted); font-size:0.85rem; margin-top:12px;">
         Status: <span id="joystick-status-text">Not connected</span>
       </div>
+      <div style="margin-top:12px; padding:8px; background:var(--surf2); border-radius:4px; font-size:0.8rem; line-height:1.5;">
+        <strong>Gamepad Setup:</strong><br/>
+        1. Connect your gamepad<br/>
+        2. Check "Show Debug Info" below<br/>
+        3. Look at "Gamepad:" line for button count<br/>
+        4. Press d-pad to verify buttons (should show [12, 13, 14, 15] for 8BitDo)<br/>
+        5. If wrong, switch gamepad to DirectInput/D-Input mode<br/>
+        <br/>
+        <strong>8BitDo Zero 2 Modes:</strong><br/>
+        • <strong>D-Input</strong> ✓ (16 buttons) - Use "8BitDo Zero 2" profile<br/>
+        • X-Input (10 buttons) - Switch to D-Input mode on controller
+      </div>
       <label class="atem-toggle-wrap" style="margin-top:12px;">
         <input id="f-joystick-debug" type="checkbox" />
         <span>Show Debug Info</span>
@@ -1601,6 +1613,8 @@
         <div>Ax0: <span id="dbg-joystick-ax0">—</span> Ax1: <span id="dbg-joystick-ax1">—</span> Ax2: <span id="dbg-joystick-ax2">—</span></div>
         <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Gamepad:</div>
         <div id="dbg-joystick-info">—</div>
+        <div style="margin-top:6px; color:var(--subtext); font-size:0.75rem;">Pressed buttons:</div>
+        <div id="dbg-joystick-buttons" style="word-wrap:break-word;">—</div>
       </div>
     </div>
   </div>
@@ -1698,6 +1712,41 @@
       axisMap: { ...defaults.axisMap, ...(joystick.axisMap || {}) },
       buttonMap: { ...defaults.buttonMap, ...(joystick.buttonMap || {}) },
     };
+  }
+
+  function detectGamepadMode() {
+    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+    const gamepad = [...gamepads].find(Boolean);
+    if (!gamepad) return null;
+
+    const id = gamepad.id.toLowerCase();
+    const btnCount = gamepad.buttons.length;
+    const axCount = gamepad.axes.length;
+
+    let detected = {
+      id: gamepad.id,
+      buttonCount: btnCount,
+      axisCount: axCount,
+      suggestion: null,
+      reason: '',
+    };
+
+    if (id.includes('8bitdo') || id.includes('8bit do')) {
+      if (btnCount >= 16 && axCount >= 2) {
+        detected.suggestion = '8bitdo-zero2';
+        detected.reason = 'DirectInput mode (D-Pad recommended)';
+      } else if (btnCount === 10) {
+        detected.suggestion = 'logitech-extreme-3d';
+        detected.reason = 'XInput mode (needs reconfiguration)';
+      } else {
+        detected.reason = `Unknown mode: ${btnCount} buttons, ${axCount} axes`;
+      }
+    } else if (id.includes('logitech') && id.includes('extreme 3d')) {
+      detected.suggestion = 'logitech-extreme-3d';
+      detected.reason = 'Analog stick mode';
+    }
+
+    return detected;
   }
 
   let state = {
@@ -2246,7 +2295,23 @@
       elDbgJoystickAx0.textContent = rawPan.toFixed(3);
       elDbgJoystickAx1.textContent = rawTilt.toFixed(3);
       elDbgJoystickAx2.textContent = rawZoom.toFixed(3);
-      elDbgJoystickInfo.textContent = `${gamepad.id} (${gamepad.buttons.length} btns, ${gamepad.axes.length} axes)`;
+
+      const detection = detectGamepadMode();
+      let infoText = `${gamepad.id} (${gamepad.buttons.length} btns, ${gamepad.axes.length} axes)`;
+      if (detection && detection.suggestion && detection.suggestion !== cfg.model) {
+        infoText += `\n⚠ Try mode: ${detection.suggestion} - ${detection.reason}`;
+      } else if (detection && detection.reason) {
+        infoText += `\n${detection.reason}`;
+      }
+      elDbgJoystickInfo.textContent = infoText;
+
+      const pressedButtons = gamepad.buttons
+        .map((btn, idx) => btn.pressed ? idx : null)
+        .filter(idx => idx !== null);
+      const elDbgButtons = document.getElementById('dbg-joystick-buttons');
+      if (elDbgButtons) {
+        elDbgButtons.textContent = pressedButtons.length > 0 ? `[${pressedButtons.join(', ')}]` : 'None';
+      }
     } else {
       elDbgJoystickPan.textContent = '—';
       elDbgJoystickTilt.textContent = '—';
@@ -2255,6 +2320,10 @@
       elDbgJoystickAx1.textContent = '—';
       elDbgJoystickAx2.textContent = '—';
       elDbgJoystickInfo.textContent = 'Not connected';
+      const elDbgButtons = document.getElementById('dbg-joystick-buttons');
+      if (elDbgButtons) {
+        elDbgButtons.textContent = '—';
+      }
     }
   }
 
@@ -2957,9 +3026,16 @@
 
   function applyGamepadInput() {
     if (!gamepadConnected) return;
-    // Debug: Log when commands are sent
-    if (gamepadState.pan === 0 && gamepadState.tilt === 0 && gamepadState.zoom === 0) {
-      console.debug('[GAMEPAD] Sending STOP command: pan=0, tilt=0, zoom=0');
+    const cmd = { pan: gamepadState.pan, tilt: -gamepadState.tilt, zoom: gamepadState.zoom };
+    const isDuplicate = cmd.pan === lastVirtualPtz.pan && cmd.tilt === lastVirtualPtz.tilt && cmd.zoom === lastVirtualPtz.zoom;
+    if (cmd.pan === 0 && cmd.tilt === 0 && cmd.zoom === 0) {
+      if (!isDuplicate) {
+        console.debug('[GAMEPAD] Sending STOP command');
+      } else {
+        console.debug('[GAMEPAD] STOP already sent, deduplicating');
+      }
+    } else {
+      console.debug('[GAMEPAD] Sending command:', cmd, isDuplicate ? '(duplicate, skipped)' : '(sent)');
     }
     sendPtzDriveCommand(gamepadState.pan, -gamepadState.tilt, gamepadState.zoom);
   }
@@ -3055,9 +3131,20 @@
   let gamepadAnimationFrame = null;
   let dpadState = { up: false, down: false, left: false, right: false };
 
+  let lastDpadState = { up: false, down: false, left: false, right: false };
+
   function updateDpadInput(gamepad, cfg) {
     if (!cfg.useDpad) return;
     const dpadMap = JOYSTICK_PROFILES[cfg.model]?.dpadMap || {};
+
+    // Validate button indices exist
+    const validIndices = [dpadMap.up, dpadMap.down, dpadMap.left, dpadMap.right]
+      .every(idx => idx !== undefined && idx < gamepad.buttons.length);
+    if (!validIndices) {
+      console.warn('[D-PAD] Invalid button indices for profile:', cfg.model, dpadMap, `gamepad has ${gamepad.buttons.length} buttons`);
+      return;
+    }
+
     const newState = {
       up: gamepad.buttons[dpadMap.up]?.pressed || false,
       down: gamepad.buttons[dpadMap.down]?.pressed || false,
@@ -3066,10 +3153,15 @@
     };
     dpadState = newState;
 
-    // Debug: Log d-pad button states
+    // Debug: Log state changes
     if (newState.up || newState.down || newState.left || newState.right) {
-      console.debug('[D-PAD]', { up: newState.up, down: newState.down, left: newState.left, right: newState.right, dpadMap });
+      console.debug('[D-PAD] Buttons pressed:', { up: newState.up, down: newState.down, left: newState.left, right: newState.right });
     }
+    if ((newState.up || newState.down || newState.left || newState.right) !==
+        (lastDpadState.up || lastDpadState.down || lastDpadState.left || lastDpadState.right)) {
+      console.debug('[D-PAD] State changed:', newState);
+    }
+    lastDpadState = newState;
 
     const deadzone = cfg.deadzone || 0.15;
     const sensitivity = cfg.sensitivity || { pan: 1.0, tilt: 1.0, zoom: 0.5 };

--- a/public/index.html
+++ b/public/index.html
@@ -3148,7 +3148,12 @@
   let lastDpadState = { up: false, down: false, left: false, right: false };
 
   function updateDpadInput(gamepad, cfg) {
-    if (!cfg.useDpad) return;
+    if (!cfg.useDpad) {
+      gamepadState.pan = 0;
+      gamepadState.tilt = 0;
+      dpadState = { up: false, down: false, left: false, right: false };
+      return;
+    }
     const dpadMap = JOYSTICK_PROFILES[cfg.model]?.dpadMap || {};
 
     // Validate button indices exist
@@ -3156,6 +3161,9 @@
       .every(idx => idx !== undefined && idx < gamepad.buttons.length);
     if (!validIndices) {
       console.warn('[D-PAD] Invalid button indices for profile:', cfg.model, dpadMap, `gamepad has ${gamepad.buttons.length} buttons`);
+      gamepadState.pan = 0;
+      gamepadState.tilt = 0;
+      dpadState = { up: false, down: false, left: false, right: false };
       return;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3410,11 +3410,10 @@
 
   function updateToolbarVisibility() {
     const btnScanEl = document.getElementById('btn-scan');
-    if (btnScanEl) btnScanEl.style.display = state.liveMode ? 'none' : '';
+    if (btnScanEl) btnScanEl.style.display = '';
     if (elAutoCutBtn) elAutoCutBtn.style.display = state.atem.enabled ? '' : 'none';
     if (elCaptureToggle) {
-      elCaptureToggle.style.display =
-        (!state.liveMode && state.atem.enabled) ? 'flex' : 'none';
+      elCaptureToggle.style.display = state.atem.enabled ? 'flex' : 'none';
     }
     updateManualCutButton();
     updateAutoCutButton();
@@ -3827,6 +3826,88 @@
     }
   }
 
+  function getRequestedCaptureBus() {
+    if (!state.atem.enabled) return null;
+    if (state.captureSource === 'preview') return 'preview';
+    if (state.captureSource === 'program') return 'program';
+    return null;
+  }
+
+  function getRequestedCaptureSource(bus = getRequestedCaptureBus()) {
+    if (bus === 'preview') return Number(state.previewSource || 0);
+    if (bus === 'program') return Number(state.programSource || 0);
+    return 0;
+  }
+
+  function validateAtemCaptureSelection(camIdx) {
+    const bus = getRequestedCaptureBus();
+    if (!bus) return { ok: true };
+
+    const expectedSource = getRequestedCaptureSource(bus);
+    const busLabel = bus === 'preview' ? 'preview' : 'program';
+    const cam = state.cameras[camIdx];
+    const camName = (cam && cam.name) || `Camera ${camIdx + 1}`;
+
+    if (!expectedSource) {
+      return {
+        ok: false,
+        error: `ATEM ${busLabel} is not confirmed yet. Wait for ATEM status or switch scan source.`,
+      };
+    }
+
+    if (!cameraMatchesAtemSource(camIdx, expectedSource)) {
+      return {
+        ok: false,
+        error: `${camName} is not on ATEM ${busLabel}. Put it there first or switch scan source.`,
+      };
+    }
+
+    if (state.captureOutput === 'activeCam') {
+      return { ok: true };
+    }
+
+    if (state.captureOutput === 'webcam') {
+      return {
+        ok: false,
+        error: `ATEM ${busLabel} capture needs a reported output. Use Active Cam routing or an SDI output instead of USB Webcam.`,
+      };
+    }
+
+    const actualSource = Number(getOutputSource(state.captureOutput) || 0);
+    if (!actualSource) {
+      return {
+        ok: false,
+        error: `${getPhysicalOutputLabel(state.captureOutput)} has no ATEM source detected. Route ${busLabel} there or switch scan output.`,
+      };
+    }
+
+    if (actualSource !== expectedSource) {
+      return {
+        ok: false,
+        error: `${getPhysicalOutputLabel(state.captureOutput)} is carrying ${formatAtemSourceSummary(actualSource)}, not ATEM ${busLabel} (${formatAtemSourceSummary(expectedSource)}).`,
+      };
+    }
+
+    return { ok: true };
+  }
+
+  async function preparePresetCapture(camIdx) {
+    const validation = validateAtemCaptureSelection(camIdx);
+    if (!validation.ok) return validation;
+
+    if (state.atem.enabled && state.captureOutput === 'activeCam') {
+      const routeResult = await routeActiveCam(camIdx);
+      if (!routeResult.ok) {
+        return {
+          ok: false,
+          error: `Could not route camera: ${routeResult.error || routeResult.message}`,
+        };
+      }
+    }
+
+    return { ok: true };
+  }
+
   function renderOutputMapTable() {
     const tbody = document.getElementById('output-map-body');
     if (!tbody) return;
@@ -4163,17 +4244,15 @@
     }
 
     try {
-      if (state.atem.enabled && state.captureOutput === 'activeCam') {
-        const routeResult = await routeActiveCam(cam);
-        if (!routeResult.ok) {
-          if (preset_btn) {
-            preset_btn.classList.remove('state-busy');
-            preset_btn.classList.add('state-fail');
-            setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
-          }
-          setStatus('error', `Could not route camera: ${routeResult.error || routeResult.message}`);
-          return;
+      const captureReady = await preparePresetCapture(cam);
+      if (!captureReady.ok) {
+        if (preset_btn) {
+          preset_btn.classList.remove('state-busy');
+          preset_btn.classList.add('state-fail');
+          setTimeout(() => preset_btn.classList.remove('state-fail'), 1500);
         }
+        setStatus('error', captureReady.error);
+        return;
       }
       const ok = await captureFrame(cam, preset);
 
@@ -4211,7 +4290,10 @@
 
   function bumpImageVersion(cam, preset) {
     const key = presetKey(cam, preset);
-    imageVersions[key] = (imageVersions[key] || 0) + 1;
+    const prev = imageVersions[key] || bootImageVersion;
+    // Image responses are immutable, so every refresh needs a cache-busting
+    // token newer than both the boot-time URL and any prior capture/delete.
+    imageVersions[key] = Math.max(Date.now(), prev + 1);
   }
 
   // ── Snap-on-drift helpers ──────────────────────────────────────────────────
@@ -4487,6 +4569,11 @@
 
   async function capturePreset(n) {
     const cam = state.activeCam;
+    const captureReady = await preparePresetCapture(cam);
+    if (!captureReady.ok) {
+      setStatus('error', captureReady.error);
+      return;
+    }
     const ok = await captureFrame(cam, n);
     if (ok) {
       clearSnapNeeded(cam, n);
@@ -4561,7 +4648,7 @@
     captureBtn.addEventListener('pointerup', (e) => e.stopPropagation());
     captureBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
-      await capturePreset(n);
+      await capturePresetImage(cam, n, captureBtn);
     });
     btn.appendChild(captureBtn);
 
@@ -4790,11 +4877,11 @@
 
     if (state.atem.enabled && state.captureOutput === 'activeCam') {
       setStatus('busy', 'Routing camera…', false);
-      const routeResult = await routeActiveCam(scanCamIdx);
-      if (!routeResult.ok) {
-        setStatus('error', `Could not route camera: ${routeResult.error || routeResult.message}`);
-        return;
-      }
+    }
+    const captureReady = await preparePresetCapture(scanCamIdx);
+    if (!captureReady.ok) {
+      setStatus('error', captureReady.error);
+      return;
     }
 
     const captureKey = (state.atem.enabled && state.captureOutput === 'activeCam')

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -80,6 +80,10 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
 
+    def test_image_cache_busting_stays_newer_than_boot_urls(self):
+        self.assertIn("const prev = imageVersions[key] || bootImageVersion;", self.html)
+        self.assertIn("imageVersions[key] = Math.max(Date.now(), prev + 1);", self.html)
+
     def test_snap_on_drift(self):
         # state and threshold
         self.assertIn("const snapNeeded = Object.create(null);", self.html)
@@ -104,6 +108,22 @@ class TestFrontendContracts(unittest.TestCase):
         # changing capture source refreshes settings panel and status hints
         self.assertIn("updateCaptureModeVisibility();", self.html)
         self.assertIn("updateCameraStatusHints();", self.html)
+
+    def test_live_scan_controls_validate_atem_bus_selection(self):
+        self.assertIn("if (btnScanEl) btnScanEl.style.display = '';", self.html)
+        self.assertIn(
+            "elCaptureToggle.style.display = state.atem.enabled ? 'flex' : 'none';",
+            self.html,
+        )
+        self.assertIn("function validateAtemCaptureSelection(camIdx)", self.html)
+        self.assertIn(
+            "${camName} is not on ATEM ${busLabel}. Put it there first or switch scan source.",
+            self.html,
+        )
+        self.assertIn(
+            "ATEM ${busLabel} capture needs a reported output. Use Active Cam routing or an SDI output instead of USB Webcam.",
+            self.html,
+        )
 
     def test_joystick_state_is_normalized_and_visible(self):
         self.assertIn(


### PR DESCRIPTION
## What changed
- added stronger gamepad diagnostics and operator guidance, including mode detection, real-time input visibility, clearer debug messaging, and a setup guide for 8BitDo controllers in `GAMEPAD_SETUP.md`
- tightened gamepad input handling so stale d-pad state and confusing mode mismatches are surfaced more clearly instead of failing silently
- kept scan controls available whenever ATEM is enabled so operators can intentionally scan the preview camera during Live mode
- added ATEM bus-aware capture validation before scan and manual Snap so the app only captures when the selected camera and selected output actually match the requested preview/program source
- reused the same capture-preparation path for bulk scan and manual snapshot capture, including Active Cam routing checks
- fixed preset thumbnail refresh after capture by using a monotonic cache-busting token, so `Scan All Presets` and manual snaps update images immediately instead of waiting for a full page reload
- expanded frontend contract coverage for both the live scan/capture validation flow and the image cache-busting behavior

## Why
This branch folds together two related operator-facing improvements.

First, controller setup issues were hard to diagnose when an 8BitDo pad was in the wrong mode or holding onto stale input state, which made live troubleshooting slower and more error-prone.

Second, live preset capture needed stronger guardrails and clearer feedback: preview-camera scans could be blocked unnecessarily in Live mode, captures could target a mismatched ATEM output, and successful captures could still look stale until the page was refreshed because the image URL cache-buster was not advancing past the boot-time version.

## Impact
- operators get clearer, faster feedback when a gamepad is misconfigured or not sending the expected d-pad input
- preview-camera scanning remains available during live workflows without weakening the protection against saving misleading preset thumbnails
- successful captures now show up immediately in the preset grid, which reduces uncertainty after `Scan All Presets` and manual `Snap`

## Validation
- `ruff check server.py`
- `python3 -m py_compile server.py`
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete setup and troubleshooting guide for 8BitDo Zero 2 gamepad configuration and mode switching.

* **New Features**
  * Enhanced debug information panel with improved gamepad mode detection and expanded diagnostic fields.

* **Bug Fixes**
  * Improved input validation for D-pad controls and camera routing compatibility checks.
  * Enhanced asset refresh logic for consistent display updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->