### PR TITLE
Add joystick speed compensation based on zoom level

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3160,12 +3160,13 @@
         }
       })
       .finally(() => {
-        if (session === zoomPollSession) zoomPollInFlight = false;
+        zoomPollInFlight = false;
       });
   }
 
   function startZoomPolling() {
     zoomPollSession += 1;
+    zoomPollInFlight = false;
     if (zoomPollTimer) clearInterval(zoomPollTimer);
     pollCameraZoom();
     zoomPollTimer = setInterval(pollCameraZoom, ZOOM_POLL_INTERVAL_MS);
@@ -3173,6 +3174,7 @@
 
   function stopZoomPolling() {
     zoomPollSession += 1;
+    zoomPollInFlight = false;
     if (zoomPollTimer) {
       clearInterval(zoomPollTimer);
       zoomPollTimer = null;

--- a/public/index.html
+++ b/public/index.html
@@ -1639,8 +1639,8 @@
       </div>
       <div style="margin-top:12px;">
         <label for="f-joystick-zoom-comp">Zoom Speed Compensation</label>
-        <span style="display:block; font-size:0.8rem; color:var(--subtext); margin-bottom:6px;">Pan/tilt sensitivity scales inversely with zoom level</span>
-        <select id="f-joystick-zoom-comp" style="width:100%; padding:6px; border:1px solid var(--border); background:var(--surf1); color:var(--text); border-radius:4px; font-size:0.9rem;">
+        <span style="display:block; font-size:0.8rem; color:var(--muted); margin-bottom:6px;">Pan/tilt sensitivity scales inversely with zoom level</span>
+        <select id="f-joystick-zoom-comp" style="width:100%; padding:6px; border:1px solid var(--border); background:var(--surf2); color:var(--text); border-radius:4px; font-size:0.9rem;">
           <option value="linear">Linear (default)</option>
           <option value="quadratic">Quadratic</option>
         </select>
@@ -3137,30 +3137,42 @@
 
   // ── Gamepad/Joystick API ───────────────────────────────────────────────────
   function pollCameraZoom() {
+    const session = zoomPollSession;
+    if (zoomPollInFlight) return;
     const camIdx = state.activeCam;
     const cam = state.cameras[camIdx];
     if (!cam || !cam.ip) {
       currentCameraZoom.value = 0;
+      currentCameraZoom.timestamp = 0;
       return;
     }
+    zoomPollInFlight = true;
     fetch(`/api/position/${camIdx}`)
       .then(res => res.ok ? res.json() : null)
       .catch(() => null)
       .then(data => {
+        if (session !== zoomPollSession) return;
         if (data && data.ok && typeof data.zoom !== 'undefined') {
           currentCameraZoom.value = parseInt(data.zoom, 10) || 0;
           currentCameraZoom.timestamp = Date.now();
+        } else {
+          currentCameraZoom = { value: 0, timestamp: 0 };
         }
+      })
+      .finally(() => {
+        if (session === zoomPollSession) zoomPollInFlight = false;
       });
   }
 
   function startZoomPolling() {
+    zoomPollSession += 1;
     if (zoomPollTimer) clearInterval(zoomPollTimer);
     pollCameraZoom();
     zoomPollTimer = setInterval(pollCameraZoom, ZOOM_POLL_INTERVAL_MS);
   }
 
   function stopZoomPolling() {
+    zoomPollSession += 1;
     if (zoomPollTimer) {
       clearInterval(zoomPollTimer);
       zoomPollTimer = null;
@@ -3188,8 +3200,10 @@
     if (!gamepadConnected) {
       gamepadConnected = true;
       console.debug('[PTZ] Gamepad connected:', gamepad.id);
-      startZoomPolling();
       updateJoystickStatus();
+    }
+    if (!zoomPollTimer && state.joystick?.enabled) {
+      startZoomPolling();
     }
 
     const cfg = state.joystick;
@@ -3394,6 +3408,8 @@
 
   let currentCameraZoom = { value: 0, timestamp: 0 };
   let zoomPollTimer = null;
+  let zoomPollSession = 0;
+  let zoomPollInFlight = false;
   const ZOOM_POLL_INTERVAL_MS = 500;
 
   function updateDpadInput(gamepad, cfg) {

--- a/public/index.html
+++ b/public/index.html
@@ -2741,7 +2741,7 @@
     state.activeCam = idx;
     state.editingPresetId = null;
     currentCameraZoom = { value: 0, timestamp: 0 };
-    if (gamepadConnected) {
+    if (gamepadConnected && state.joystick?.enabled) {
       startZoomPolling();
     }
     schedSave();
@@ -3293,11 +3293,12 @@
   window.addEventListener('gamepadconnected', (e) => {
     gamepadConnected = true;
     console.debug('[PTZ] Gamepad connected:', e.gamepad.id);
-    updateJoystickStatus();
-    updateJoystickDebug();
     if (state.joystick && state.joystick.enabled) {
+      startZoomPolling();
       updateGamepadState();
     }
+    updateJoystickStatus();
+    updateJoystickDebug();
   });
 
   window.addEventListener('gamepaddisconnected', (e) => {
@@ -3938,6 +3939,7 @@
         gamepadAnimationFrame = null;
       }
       gamepadState = { pan: 0, tilt: 0, zoom: 0 };
+      stopZoomPolling();
       sendPtzDriveCommand(0, 0, 0);
     } else if (!wasEnabled && state.joystick.enabled) {
       const connectedGamepads = typeof navigator !== 'undefined' && navigator.getGamepads
@@ -3945,6 +3947,7 @@
         : [];
       if (connectedGamepads.length > 0) {
         gamepadConnected = true;
+        startZoomPolling();
         if (!gamepadAnimationFrame) {
           updateGamepadState();
         }

--- a/public/index.html
+++ b/public/index.html
@@ -1637,6 +1637,14 @@
         <input id="f-joystick-zoom-sens" type="range" min="0.1" max="2" step="0.1" value="0.5" />
         <span id="f-joystick-zoom-value">0.5x</span>
       </div>
+      <div style="margin-top:12px;">
+        <label for="f-joystick-zoom-comp">Zoom Speed Compensation</label>
+        <span style="display:block; font-size:0.8rem; color:var(--subtext); margin-bottom:6px;">Pan/tilt sensitivity scales inversely with zoom level</span>
+        <select id="f-joystick-zoom-comp" style="width:100%; padding:6px; border:1px solid var(--border); background:var(--surf1); color:var(--text); border-radius:4px; font-size:0.9rem;">
+          <option value="linear">Linear (default)</option>
+          <option value="quadratic">Quadratic</option>
+        </select>
+      </div>
       <div id="joystick-status" style="color:var(--muted); font-size:0.85rem; margin-top:12px;">
         Status: <span id="joystick-status-text">Not connected</span>
       </div>
@@ -1757,6 +1765,7 @@
       sensitivity: { ...profile.sensitivity },
       axisMap: { ...profile.axisMap },
       buttonMap: { ...profile.buttonMap },
+      zoomCompensationCurve: "linear",
     };
 
     return {
@@ -2731,6 +2740,10 @@
     saveCameraSettings();
     state.activeCam = idx;
     state.editingPresetId = null;
+    currentCameraZoom = { value: 0, timestamp: 0 };
+    if (gamepadConnected) {
+      startZoomPolling();
+    }
     schedSave();
     loadCameraSettings();
     updateCameraSelectUi();
@@ -3123,6 +3136,38 @@
   }
 
   // ── Gamepad/Joystick API ───────────────────────────────────────────────────
+  function pollCameraZoom() {
+    const camIdx = state.activeCam;
+    const cam = state.cameras[camIdx];
+    if (!cam || !cam.ip) {
+      currentCameraZoom.value = 0;
+      return;
+    }
+    fetch(`/api/position/${camIdx}`)
+      .then(res => res.ok ? res.json() : null)
+      .catch(() => null)
+      .then(data => {
+        if (data && data.ok && typeof data.zoom !== 'undefined') {
+          currentCameraZoom.value = parseInt(data.zoom, 10) || 0;
+          currentCameraZoom.timestamp = Date.now();
+        }
+      });
+  }
+
+  function startZoomPolling() {
+    if (zoomPollTimer) clearInterval(zoomPollTimer);
+    pollCameraZoom();
+    zoomPollTimer = setInterval(pollCameraZoom, ZOOM_POLL_INTERVAL_MS);
+  }
+
+  function stopZoomPolling() {
+    if (zoomPollTimer) {
+      clearInterval(zoomPollTimer);
+      zoomPollTimer = null;
+    }
+    currentCameraZoom = { value: 0, timestamp: 0 };
+  }
+
   function updateGamepadState() {
     if (!state.joystick || !state.joystick.enabled) return;
 
@@ -3132,6 +3177,7 @@
       if (gamepadConnected) {
         gamepadConnected = false;
         gamepadState = { pan: 0, tilt: 0, zoom: 0 };
+        stopZoomPolling();
         sendPtzDriveCommand(0, 0, 0);
         console.debug('[PTZ] Gamepad disconnected');
         updateJoystickStatus();
@@ -3142,6 +3188,7 @@
     if (!gamepadConnected) {
       gamepadConnected = true;
       console.debug('[PTZ] Gamepad connected:', gamepad.id);
+      startZoomPolling();
       updateJoystickStatus();
     }
 
@@ -3202,9 +3249,31 @@
     }
   }
 
+  function calculateZoomCompensation(zoomValue, curve) {
+    if (!zoomValue) return 1.0;
+    const maxZoom = 32767;
+    const ratio = Math.max(0, Math.min(1, zoomValue / maxZoom));
+    if (curve === 'quadratic') {
+      return 1 / (1 + (ratio * ratio) * 9);
+    }
+    return 1 / (1 + ratio * 9);
+  }
+
   function applyGamepadInput() {
     if (!gamepadConnected) return;
-    const cmd = { pan: gamepadState.pan, tilt: -gamepadState.tilt, zoom: gamepadState.zoom };
+    let pan = gamepadState.pan;
+    let tilt = gamepadState.tilt;
+    const zoom = gamepadState.zoom;
+
+    const cfg = state.joystick || {};
+    if (cfg.enabled && pan !== 0 || tilt !== 0) {
+      const curve = cfg.zoomCompensationCurve || 'linear';
+      const compensation = calculateZoomCompensation(currentCameraZoom.value, curve);
+      pan *= compensation;
+      tilt *= compensation;
+    }
+
+    const cmd = { pan: pan, tilt: -tilt, zoom: zoom };
     const isDuplicate = cmd.pan === lastVirtualPtz.pan && cmd.tilt === lastVirtualPtz.tilt && cmd.zoom === lastVirtualPtz.zoom;
     if (state.showJoystickDebug) {
       if (cmd.pan === 0 && cmd.tilt === 0 && cmd.zoom === 0) {
@@ -3217,7 +3286,7 @@
         console.debug('[GAMEPAD] Sending command:', cmd, isDuplicate ? '(duplicate, skipped)' : '(sent)');
       }
     }
-    sendPtzDriveCommand(gamepadState.pan, -gamepadState.tilt, gamepadState.zoom);
+    sendPtzDriveCommand(pan, -tilt, zoom);
   }
 
   // Initialize gamepad support
@@ -3235,6 +3304,7 @@
     gamepadConnected = false;
     gamepadState = { pan: 0, tilt: 0, zoom: 0 };
     gamepadButtonStates = {};
+    stopZoomPolling();
     sendPtzDriveCommand(0, 0, 0);
     console.debug('[PTZ] Gamepad disconnected');
     updateJoystickStatus();
@@ -3320,6 +3390,10 @@
 
   let lastDpadState = { up: false, down: false, left: false, right: false };
   let lastDpadValid = true;
+
+  let currentCameraZoom = { value: 0, timestamp: 0 };
+  let zoomPollTimer = null;
+  const ZOOM_POLL_INTERVAL_MS = 500;
 
   function updateDpadInput(gamepad, cfg) {
     if (!cfg.useDpad) {
@@ -3693,6 +3767,7 @@
   const elJoystickPanSens = document.getElementById('f-joystick-pan-sens');
   const elJoystickTiltSens = document.getElementById('f-joystick-tilt-sens');
   const elJoystickZoomSens = document.getElementById('f-joystick-zoom-sens');
+  const elJoystickZoomComp = document.getElementById('f-joystick-zoom-comp');
   const elJoystickStatus = document.getElementById('joystick-status-text');
   const elJoystickDebug = document.getElementById('joystick-debug');
   const elJoystickDebugCheckbox = document.getElementById('f-joystick-debug');
@@ -3827,6 +3902,9 @@
       elJoystickZoomSens.value = (js.sensitivity?.zoom || 0.5).toFixed(1);
       document.getElementById('f-joystick-zoom-value').textContent = (js.sensitivity?.zoom || 0.5).toFixed(1) + 'x';
     }
+    if (elJoystickZoomComp) {
+      elJoystickZoomComp.value = js.zoomCompensationCurve || 'linear';
+    }
     updateVirtualJoystickVisibility();
     updateJoystickStatus();
   }
@@ -3845,6 +3923,7 @@
         tilt: parseFloat(elJoystickTiltSens?.value || 1.0),
         zoom: parseFloat(elJoystickZoomSens?.value || 0.5),
       },
+      zoomCompensationCurve: elJoystickZoomComp?.value || 'linear',
     });
 
     state.virtualJoystick = {
@@ -3895,7 +3974,7 @@
   }
 
   if (elJoystickEnabled) {
-    [elJoystickEnabled, elJoystickModel, elJoystickDeadzone, elJoystickPanSens, elJoystickTiltSens, elJoystickZoomSens].forEach(el => {
+    [elJoystickEnabled, elJoystickModel, elJoystickDeadzone, elJoystickPanSens, elJoystickTiltSens, elJoystickZoomSens, elJoystickZoomComp].forEach(el => {
       if (el) {
         el.addEventListener('change', saveJoystickSettings);
         el.addEventListener('input', () => {

--- a/server.py
+++ b/server.py
@@ -138,6 +138,7 @@ DEFAULT_SETTINGS = {
             "preset3": 2,
             "preset4": 3,
         },
+        "zoomCompensationCurve": "linear",
     },
     "virtualJoystick": {
         "enabled": True,


### PR DESCRIPTION
## Summary

Implements automatic zoom-based speed compensation for joystick pan/tilt movements. This feature addresses the problem where joystick control becomes insensitive when zoomed in and overly fast when zoomed out.

**How it works:**
- Pan/tilt sensitivity automatically scales inversely with the camera's zoom level
- At wide zoom: full speed (1.0x multiplier)
- At maximum zoom: reduced speed (~0.1x multiplier)
- Smooth transitions as zoom changes during movement

## Implementation Details

### Backend (server.py)
- Added `zoomCompensationCurve: "linear"` to joystick settings in DEFAULT_SETTINGS

### Frontend (public/index.html)
- **Zoom polling**: Fetches camera absolute position (zoom value) every 500ms when gamepad is connected
- **Compensation algorithm**: Supports linear and quadratic curves
  - Linear: `multiplier = 1 / (1 + zoom_ratio * 9)`
  - Quadratic: `multiplier = 1 / (1 + (zoom_ratio^2) * 9)`
- **UI control**: Dropdown selector for "Linear (default)" and "Quadratic" curves
- **Auto-enable**: Compensation activates whenever joystick is enabled (no separate toggle)
- **Smart polling**: 
  - Starts when gamepad connects
  - Stops on disconnect or camera switch
  - Gracefully degrades if fetch fails (uses 1.0x neutral)

### Settings
- Stored in `settings.json` under `joystick.zoomCompensationCurve`
- Persists across app restarts

## Test Plan

1. Connect a gamepad and enable joystick in settings
2. Move to Settings → Joystick and verify "Zoom Speed Compensation" dropdown appears (default: Linear)
3. Test without compensation:
   - Pan/tilt speed should remain constant at all zoom levels
4. Test linear compensation:
   - At zoom 0 (wide): pan/tilt responds quickly
   - At maximum zoom: pan/tilt moves slowly and precisely
   - Smooth gradation as zoom changes
5. Test quadratic compensation:
   - More aggressive slowdown at high zoom than linear
6. Test edge cases:
   - Switch cameras mid-movement → compensation re-syncs to new camera
   - Disconnect gamepad → polling stops
   - Camera with no IP → graceful fallback to 1.0x
7. Verify settings persist in `data/settings.json`

## Notes

- Zoom polling interval is 500ms; future improvement could use SSE for push-based updates
- Only pan/tilt are compensated; zoom axis speed remains constant
- Compensation is transparent to existing preset recall and scan workflows

---
_Generated by [Claude Code](https://claude.ai/code/session_0113rPBmnWJpuhPuBRJMDYKL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Zoom Speed Compensation for PTZ joystick controls with selectable curves (Linear or Quadratic).
  * UI control to choose compensation mode and persist settings between sessions.
  * Automatic zoom-level polling and tracking to keep joystick responsiveness consistent across zoom levels.
  * Compensation applied to pan/tilt drive behavior; polling starts/stops with gamepad connection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->