### PR TITLE
[codex] Reduce PTZ stop latency after joystick release

### DIFF
--- a/server.py
+++ b/server.py
@@ -46,6 +46,7 @@ except ImportError:
 _IS_MACOS = platform.system() == "Darwin"
 
 _logger = logging.getLogger(__name__)
+VISCA_DRIVE_COMMAND_TIMEOUT_S = 0.05
 
 # ── Paths ──────────────────────────────────────────────────────────────────────
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -1167,7 +1168,13 @@ def send_visca_pan_tilt_drive(
     pan_speed = max(1, min(0x18, int(pan_speed or 1)))
     tilt_speed = max(1, min(0x18, int(tilt_speed or 1)))
     command = bytes([0x01, 0x06, 0x01, pan_speed, tilt_speed, pan_dir, tilt_dir])
-    return send_visca_command(ip, port, command, camera_address=camera_address)
+    return send_visca_command(
+        ip,
+        port,
+        command,
+        camera_address=camera_address,
+        timeout_s=VISCA_DRIVE_COMMAND_TIMEOUT_S,
+    )
 
 
 def send_visca_zoom_drive(
@@ -1180,7 +1187,13 @@ def send_visca_zoom_drive(
     else:
         zoom_cmd = 0x20 | zoom_speed if zoom_value > 0 else 0x30 | zoom_speed
     command = bytes([0x01, 0x04, 0x07, zoom_cmd])
-    return send_visca_command(ip, port, command, camera_address=camera_address)
+    return send_visca_command(
+        ip,
+        port,
+        command,
+        camera_address=camera_address,
+        timeout_s=VISCA_DRIVE_COMMAND_TIMEOUT_S,
+    )
 
 
 def inquire_visca_pan_tilt_position(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -493,6 +493,47 @@ class TestViscaPackets(unittest.TestCase):
         self.assertIn("ACK", msg)
         self.assertIn("Completion", msg)
 
+    def test_pan_tilt_drive_uses_low_latency_timeout(self):
+        with patch(
+            "server.send_visca_command", return_value=(True, "Command sent")
+        ) as mock_send:
+            ok, msg = server.send_visca_pan_tilt_drive(
+                "10.0.0.1",
+                52381,
+                6,
+                5,
+                0x02,
+                0x01,
+                camera_address=3,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(msg, "Command sent")
+        mock_send.assert_called_once()
+        self.assertEqual(
+            mock_send.call_args.kwargs["timeout_s"],
+            server.VISCA_DRIVE_COMMAND_TIMEOUT_S,
+        )
+
+    def test_zoom_drive_uses_low_latency_timeout(self):
+        with patch(
+            "server.send_visca_command", return_value=(True, "Command sent")
+        ) as mock_send:
+            ok, msg = server.send_visca_zoom_drive(
+                "10.0.0.1",
+                52381,
+                0.5,
+                camera_address=2,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(msg, "Command sent")
+        mock_send.assert_called_once()
+        self.assertEqual(
+            mock_send.call_args.kwargs["timeout_s"],
+            server.VISCA_DRIVE_COMMAND_TIMEOUT_S,
+        )
+
 
 class TestRecallProbeModes(unittest.TestCase):
     def test_confirm_mode_treats_command_send_as_success(self):


### PR DESCRIPTION
## Summary
- reduce VISCA timeout for continuous PTZ drive packets so stop commands can reach the camera much sooner after joystick release
- keep preset recall and other VISCA command behavior unchanged by scoping the shorter timeout to pan/tilt and zoom drive commands only
- add regression tests that lock the low-latency timeout onto continuous drive commands

## Why
The virtual joystick could still leave the camera moving after release because a queued stop had to wait behind an in-flight PTZ move request. Each move request could spend up to 0.5 seconds waiting for VISCA responses, and a typical move sends both pan/tilt and zoom drive packets, stretching the stop delay into multiple seconds.

## Validation
- `ruff format --check server.py`
- `ruff check server.py tests/test_server.py`
- `python -m py_compile server.py`
- `uv run pytest tests/test_server.py -k "ptz or drive or ViscaPackets"`
- `uv run pytest tests/test_frontend_contracts.py tests/test_server.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized timeout handling for camera pan, tilt, and zoom operations to improve responsiveness.

* **Tests**
  * Added test coverage to verify timeout behavior for drive operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/105)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->