### PR TITLE
[codex] Add running version endpoint and tune virtual joystick feel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2123,8 +2123,23 @@
   let statusTimer    = null;
 
   if (elBuildCommit) elBuildCommit.textContent = BUILD_COMMIT;
+  if (elBuildCommit) elBuildCommit.title = `build ${BUILD_COMMIT}`;
   if (elStatus) elStatus.title = elStatusText.textContent;
   if (elStatusText) elStatusText.title = elStatusText.textContent;
+
+  function applyBuildVersion(version) {
+    if (!elBuildCommit || !version || !version.gitAvailable) return;
+    const shortCommit = version.shortCommit || BUILD_COMMIT;
+    const branch = version.branch || '(detached)';
+    const dirty = version.dirty ? 'dirty' : 'clean';
+    const defaultState = version.headMatchesLocalDefault === true
+      ? `matches ${version.localDefaultRef || 'default'}`
+      : version.headMatchesLocalDefault === false
+        ? `differs from ${version.localDefaultRef || 'default'}`
+        : 'default ref unavailable';
+    elBuildCommit.textContent = shortCommit;
+    elBuildCommit.title = `${branch} @ ${shortCommit} (${dirty}, ${defaultState})`;
+  }
 
   function updateBuildIndicator() {
     if (!elBuildMode) return;
@@ -5540,6 +5555,10 @@
         if (elPlaywright) elPlaywright.style.display = 'block';
         if (elWarnings) elWarnings.style.display = 'block';
       }
+    } catch (_) {}
+    try {
+      const version = await fetch('/api/version').then(r => r.ok ? r.json() : null);
+      if (version) applyBuildVersion(version);
     } catch (_) {}
     // USB devices from server — store for use in output-map table
     try {

--- a/public/index.html
+++ b/public/index.html
@@ -3032,6 +3032,7 @@
 
   let virtualJoystickActive = false;
   let virtualJoystickTouchId = null;
+  let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
   const ptzDriveController = {
     desiredCommand: { pan: 0, tilt: 0, zoom: 0 },
     lastSentCommand: null,
@@ -3137,10 +3138,29 @@
     return sendPtzDriveCommand(0, 0, 0, source);
   }
 
+  function applyVirtualJoystickResponseCurve(value) {
+    const n = Math.max(-1, Math.min(1, Number(value) || 0));
+    if (!n) return 0;
+    return Math.sign(n) * Math.pow(Math.abs(n), 1.6);
+  }
+
+  function applyVirtualJoystickSnapbackGuard(next, previous) {
+    if (!next || !previous) return next;
+    if (Math.sign(next) !== Math.sign(previous)) {
+      const reverseGuard = Math.max(
+        0.25,
+        (state.virtualJoystick?.deadzone || 0.20) + 0.15
+      );
+      if (Math.abs(next) < reverseGuard) return 0;
+    }
+    return next;
+  }
+
   function showVirtualJoystick(show) {
     virtualJoystickActive = show;
     if (!show) {
       virtualJoystickTouchId = null;
+      lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       if (elJoystickCenter) {
         elJoystickCenter.style.transform = 'translate(-50%, -50%)';
@@ -3193,6 +3213,9 @@
       if (Math.abs(pan) < deadzone) pan = 0;
       if (Math.abs(tilt) < deadzone) tilt = 0;
 
+      pan = applyVirtualJoystickResponseCurve(pan);
+      tilt = applyVirtualJoystickResponseCurve(tilt);
+
       // Apply sensitivity from settings
       const sens = state.virtualJoystick?.sensitivity || { pan: 1.0, tilt: 1.0, zoom: 0.5 };
       pan *= (sens.pan || 1.0);
@@ -3202,12 +3225,21 @@
       pan = Math.round(pan * 10) / 10;
       tilt = Math.round(tilt * 10) / 10;
 
+      pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);
+      tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);
+      lastVirtualJoystickCommand = { pan, tilt };
+
       sendPtzDriveCommand(pan, tilt, 0, 'virtual');
-      console.debug('[PTZ] Virtual joystick:', { pan: pan.toFixed(2), tilt: tilt.toFixed(2), rawDistance: distance.toFixed(2) });
+      console.debug('[PTZ] Virtual joystick:', {
+        pan: pan.toFixed(2),
+        tilt: tilt.toFixed(2),
+        rawDistance: distance.toFixed(2),
+      });
     }
 
     function resetJoystick() {
       elJoystickCenter.style.transform = 'translate(-50%, -50%)';
+      lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       console.debug('[PTZ] Virtual joystick reset to center');
     }

--- a/server.py
+++ b/server.py
@@ -178,6 +178,53 @@ def _normalize_scan_wait_mode(wait_mode: str | None) -> str:
     return normalized if normalized in {"dwell", "settle"} else "settle"
 
 
+def _run_git_command(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", _HERE, *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _get_version_info() -> dict:
+    head_commit = _run_git_command(["rev-parse", "HEAD"])
+    short_commit = _run_git_command(["rev-parse", "--short", "HEAD"])
+    branch = _run_git_command(["branch", "--show-current"]) or "(detached)"
+    dirty_output = _run_git_command(["status", "--porcelain"])
+    dirty = bool(dirty_output)
+
+    local_default_ref = None
+    local_default_commit = None
+    for ref in ("origin/default", "default"):
+        ref_commit = _run_git_command(["rev-parse", ref])
+        if ref_commit:
+            local_default_ref = ref
+            local_default_commit = ref_commit
+            break
+
+    git_available = bool(head_commit and short_commit)
+    return {
+        "gitAvailable": git_available,
+        "branch": branch if git_available else None,
+        "commit": head_commit,
+        "shortCommit": short_commit,
+        "dirty": dirty if git_available else None,
+        "localDefaultRef": local_default_ref,
+        "localDefaultCommit": local_default_commit,
+        "headMatchesLocalDefault": (
+            head_commit == local_default_commit
+            if git_available and local_default_commit
+            else None
+        ),
+    }
+
+
 def _probe_recall_command_succeeded(result: ProbeResult) -> bool:
     if result.error is not None:
         return False
@@ -1746,6 +1793,8 @@ class Handler(BaseHTTPRequestHandler):
                     else "Playwright not installed. Run: pip install playwright && playwright install chromium",
                 },
             )
+        elif path == "/api/version":
+            self._json(200, _get_version_info())
         elif m := re.match(r"^/api/position/(\d+)$", path):
             self._get_position(int(m.group(1)))
         elif m := re.match(r"^/api/image/(\d+)/(\d+)/position$", path):

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -148,6 +148,14 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
 
+    def test_build_indicator_uses_version_endpoint(self):
+        self.assertIn("function applyBuildVersion(version)", self.html)
+        self.assertIn("fetch('/api/version')", self.html)
+        self.assertIn(
+            "elBuildCommit.title = `${branch} @ ${shortCommit} (${dirty}, ${defaultState})`;",
+            self.html,
+        )
+
     def test_joystick_state_is_normalized_and_visible(self):
         self.assertIn(
             'id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem"',

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -169,6 +169,26 @@ class TestFrontendContracts(unittest.TestCase):
         )
         self.assertIn("state.joystick = normalizeJoystickSettings({", self.html)
 
+    def test_virtual_joystick_response_curve_and_snapback_guard_present(self):
+        self.assertIn("let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };", self.html)
+        self.assertIn("function applyVirtualJoystickResponseCurve(value)", self.html)
+        self.assertIn(
+            "return Math.sign(n) * Math.pow(Math.abs(n), 1.6);",
+            self.html,
+        )
+        self.assertIn(
+            "function applyVirtualJoystickSnapbackGuard(next, previous)",
+            self.html,
+        )
+        self.assertIn(
+            "pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);",
+            self.html,
+        )
+        self.assertIn(
+            "tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);",
+            self.html,
+        )
+
     def test_dpad_invalid_warn_is_deduplicated(self):
         # Deduplication guard variable is initialized to true (valid by default).
         self.assertIn("let lastDpadValid = true;", self.html)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -835,6 +835,23 @@ class TestHTTPRoutes(unittest.TestCase):
         data = json.loads(body)
         self.assertIn("cameras", data)
 
+    def test_get_version_returns_git_metadata(self):
+        version_info = {
+            "gitAvailable": True,
+            "branch": "codex/test",
+            "commit": "abc123def456",
+            "shortCommit": "abc123d",
+            "dirty": False,
+            "localDefaultRef": "origin/default",
+            "localDefaultCommit": "fff111",
+            "headMatchesLocalDefault": False,
+        }
+        with patch("server._get_version_info", return_value=version_info):
+            status, body = self.srv.get("/api/version")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body), version_info)
+
     def test_post_settings_persists(self):
         payload = json.dumps({"activeCam": 2, "cameras": [], "labels": {}}).encode()
         status, body = self.srv.post("/settings", payload)


### PR DESCRIPTION
## Summary
- add `/api/version` so the running app can report its current Git commit, branch, dirty state, and whether it matches the locally known default ref
- wire the footer build indicator to that endpoint so the served UI reflects the code actually running instead of only a hardcoded commit string
- soften virtual joystick response near center and add a snapback guard to suppress tiny reverse commands at release

## Why
After the PTZ stop-latency fix merged, there were still two practical needs:
- operators need a direct way to verify that a running instance is serving the expected code rather than a stale branch or outdated checkout
- the virtual joystick still felt too sensitive near center and could show a small opposite-direction twitch on release

## Validation
- `ruff check server.py tests/test_server.py tests/test_frontend_contracts.py`
- `python -m py_compile server.py`
- `uv run pytest tests/test_frontend_contracts.py tests/test_server.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced build indicator with dynamic commit and branch status information
  * Improved virtual joystick touch control with non-linear response curve and refined deadzone behavior

* **Tests**
  * Added frontend contract and server integration tests for new functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->