### PR TITLE
[codex] Add virtual joystick size modes and smoother release handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2123,8 +2123,23 @@
   let statusTimer    = null;
 
   if (elBuildCommit) elBuildCommit.textContent = BUILD_COMMIT;
+  if (elBuildCommit) elBuildCommit.title = `build ${BUILD_COMMIT}`;
   if (elStatus) elStatus.title = elStatusText.textContent;
   if (elStatusText) elStatusText.title = elStatusText.textContent;
+
+  function applyBuildVersion(version) {
+    if (!elBuildCommit || !version || !version.gitAvailable) return;
+    const shortCommit = version.shortCommit || BUILD_COMMIT;
+    const branch = version.branch || '(detached)';
+    const dirty = version.dirty ? 'dirty' : 'clean';
+    const defaultState = version.headMatchesLocalDefault === true
+      ? `matches ${version.localDefaultRef || 'default'}`
+      : version.headMatchesLocalDefault === false
+        ? `differs from ${version.localDefaultRef || 'default'}`
+        : 'default ref unavailable';
+    elBuildCommit.textContent = shortCommit;
+    elBuildCommit.title = `${branch} @ ${shortCommit} (${dirty}, ${defaultState})`;
+  }
 
   function updateBuildIndicator() {
     if (!elBuildMode) return;
@@ -5540,6 +5555,10 @@
         if (elPlaywright) elPlaywright.style.display = 'block';
         if (elWarnings) elWarnings.style.display = 'block';
       }
+    } catch (_) {}
+    try {
+      const version = await fetch('/api/version').then(r => r.ok ? r.json() : null);
+      if (version) applyBuildVersion(version);
     } catch (_) {}
     // USB devices from server — store for use in output-map table
     try {

--- a/public/index.html
+++ b/public/index.html
@@ -1638,6 +1638,14 @@
         <input id="f-virtual-joystick-enabled" type="checkbox" />
         <span>Enable Virtual Joystick Button</span>
       </label>
+      <div class="field">
+        <label for="f-virtual-joystick-size">Virtual Joystick Size</label>
+        <select id="f-virtual-joystick-size">
+          <option value="normal">Normal</option>
+          <option value="double">Double</option>
+          <option value="fullscreen">Full Screen</option>
+        </select>
+      </div>
       <label class="atem-toggle-wrap">
         <input id="f-joystick-enabled" type="checkbox" />
         <span>Enable Physical Joystick</span>
@@ -1761,6 +1769,7 @@
 <!-- Virtual Joystick for Touch Devices -->
 <div id="virtual-joystick-container" style="display:none; position:fixed; bottom:20px; left:20px; z-index:100; touch-action:none;">
   <button id="joystick-close-btn" style="position:absolute; top:-12px; right:-12px; width:28px; height:28px; padding:0; border:1px solid var(--border); background:var(--surf); color:var(--text); border-radius:999px; font-size:14px; cursor:pointer;">×</button>
+  <button id="joystick-size-btn" style="position:absolute; top:-12px; left:-12px; min-width:40px; height:28px; padding:0 8px; border:1px solid var(--border); background:var(--surf); color:var(--text); border-radius:999px; font-size:12px; font-weight:600; cursor:pointer;">1x</button>
   <div id="virtual-joystick" style="position:relative; width:120px; height:120px; background:var(--surf2); border:2px solid var(--border); border-radius:50%; display:flex; align-items:center; justify-content:center; cursor:grab; user-select:none;">
     <div id="joystick-center" style="position:absolute; width:40px; height:40px; background:var(--accent); border-radius:50%; top:50%; left:50%; transform:translate(-50%,-50%); transition:all 0.05s ease-out; box-shadow:0 2px 8px rgba(0,0,0,0.3);"></div>
     <div style="position:absolute; width:100%; height:100%; border:1px dashed var(--border); border-radius:50%; opacity:0.3;"></div>
@@ -1828,6 +1837,23 @@
       sensitivity: { ...defaults.sensitivity, ...(joystick.sensitivity || {}) },
       axisMap: { ...defaults.axisMap, ...(joystick.axisMap || {}) },
       buttonMap: { ...defaults.buttonMap, ...(joystick.buttonMap || {}) },
+    };
+  }
+
+  function normalizeVirtualJoystickSettings(value) {
+    const virtual = value && typeof value === 'object' ? value : {};
+    const size = ['normal', 'double', 'fullscreen'].includes(virtual.size) ? virtual.size : 'normal';
+    const deadzone = Number.isFinite(+virtual.deadzone) ? Math.max(0, Math.min(0.8, +virtual.deadzone)) : 0.25;
+    return {
+      enabled: virtual.enabled !== false,
+      size,
+      deadzone,
+      sensitivity: {
+        pan: 0.6,
+        tilt: 0.6,
+        zoom: 0.3,
+        ...(virtual.sensitivity || {}),
+      },
     };
   }
 
@@ -1904,7 +1930,7 @@
     activeCamAux: 'sdi1',
     positions: {},
     joystick: normalizeJoystickSettings(),
-    virtualJoystick: { enabled: true, deadzone: 0.25, sensitivity: { pan: 0.6, tilt: 0.6, zoom: 0.3 } },
+    virtualJoystick: normalizeVirtualJoystickSettings(),
     // Runtime ATEM AUX sources (not persisted, updated via SSE)
     aux1Source: 0,
     aux2Source: 0,
@@ -2066,7 +2092,7 @@
         if (s.activeCamAux) state.activeCamAux = normalizeActiveCamAux(s.activeCamAux);
         if (s.positions) state.positions = { ...s.positions };
         if (s.joystick) state.joystick = normalizeJoystickSettings(s.joystick);
-        if (s.virtualJoystick) state.virtualJoystick = { enabled: s.virtualJoystick.enabled !== false, deadzone: s.virtualJoystick.deadzone || 0.20, sensitivity: { ...s.virtualJoystick.sensitivity } };
+        if (s.virtualJoystick) state.virtualJoystick = normalizeVirtualJoystickSettings(s.virtualJoystick);
         if (s.deviceSettings) state.deviceSettings = { ...s.deviceSettings };
       }
     } catch (_) {}
@@ -3042,12 +3068,14 @@
   const elVirtualJoystickBtn = document.getElementById('virtual-joystick-btn');
   const elVirtualJoystickContainer = document.getElementById('virtual-joystick-container');
   const elJoystickCloseBtn = document.getElementById('joystick-close-btn');
+  const elJoystickSizeBtn = document.getElementById('joystick-size-btn');
   const elJoystickZoomUp = document.getElementById('joystick-zoom-up');
   const elJoystickZoomDown = document.getElementById('joystick-zoom-down');
 
   let virtualJoystickActive = false;
   let virtualJoystickTouchId = null;
   let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
+  let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
   const ptzDriveController = {
     desiredCommand: { pan: 0, tilt: 0, zoom: 0 },
     lastSentCommand: null,
@@ -3156,19 +3184,111 @@
   function applyVirtualJoystickResponseCurve(value) {
     const n = Math.max(-1, Math.min(1, Number(value) || 0));
     if (!n) return 0;
-    return Math.sign(n) * Math.pow(Math.abs(n), 1.6);
+    return Math.sign(n) * Math.pow(Math.abs(n), 1.9);
   }
 
-  function applyVirtualJoystickSnapbackGuard(next, previous) {
+  function applyVirtualJoystickSnapbackGuard(next, previous, axis) {
     if (!next || !previous) return next;
     if (Math.sign(next) !== Math.sign(previous)) {
       const reverseGuard = Math.max(
         0.25,
         (state.virtualJoystick?.deadzone || 0.20) + 0.15
       );
-      if (Math.abs(next) < reverseGuard) return 0;
+      if (Math.abs(next) < reverseGuard) {
+        pendingVirtualJoystickDirection[axis] = 0;
+        return 0;
+      }
+      const nextDirection = Math.sign(next);
+      if (pendingVirtualJoystickDirection[axis] !== nextDirection) {
+        pendingVirtualJoystickDirection[axis] = nextDirection;
+        return 0;
+      }
     }
+    pendingVirtualJoystickDirection[axis] = 0;
     return next;
+  }
+
+  const VIRTUAL_JOYSTICK_SIZE_ORDER = ['normal', 'double', 'fullscreen'];
+
+  function getVirtualJoystickMetrics() {
+    const size = state.virtualJoystick?.size || 'normal';
+    if (size === 'double') {
+      return { diameter: 240, handle: 72, zoomOffset: 52, labelMargin: 10 };
+    }
+    if (size === 'fullscreen') {
+      const diameter = Math.max(220, Math.min(window.innerWidth, window.innerHeight) - 64);
+      const handle = Math.max(56, Math.min(96, Math.round(diameter * 0.3)));
+      return { diameter, handle, zoomOffset: 64, labelMargin: 14 };
+    }
+    return { diameter: 120, handle: 40, zoomOffset: 40, labelMargin: 8 };
+  }
+
+  function applyVirtualJoystickLayout() {
+    if (!elVirtualJoystickContainer || !elVirtualJoystick || !elJoystickCenter) return;
+    const size = state.virtualJoystick?.size || 'normal';
+    const metrics = getVirtualJoystickMetrics();
+    const isFullscreen = size === 'fullscreen';
+    const overlaySpace = Math.max(24, (window.innerHeight - metrics.diameter) / 2 - 36);
+    const sizeLabel = size === 'double' ? '2x' : (isFullscreen ? 'Full' : '1x');
+
+    elVirtualJoystickContainer.style.inset = isFullscreen ? '0' : 'auto';
+    elVirtualJoystickContainer.style.top = isFullscreen ? '0' : 'auto';
+    elVirtualJoystickContainer.style.right = 'auto';
+    elVirtualJoystickContainer.style.bottom = isFullscreen ? '0' : '20px';
+    elVirtualJoystickContainer.style.left = isFullscreen ? '0' : '20px';
+    elVirtualJoystickContainer.style.width = isFullscreen ? '100vw' : `${metrics.diameter}px`;
+    elVirtualJoystickContainer.style.height = isFullscreen ? '100vh' : 'auto';
+    elVirtualJoystickContainer.style.background = isFullscreen ? 'rgba(5, 15, 24, 0.22)' : 'transparent';
+
+    elVirtualJoystick.style.width = `${metrics.diameter}px`;
+    elVirtualJoystick.style.height = `${metrics.diameter}px`;
+    elVirtualJoystick.style.margin = isFullscreen ? `${overlaySpace}px auto 0` : '0';
+
+    elJoystickCenter.style.width = `${metrics.handle}px`;
+    elJoystickCenter.style.height = `${metrics.handle}px`;
+
+    if (elJoystickCloseBtn) {
+      elJoystickCloseBtn.style.top = isFullscreen ? '20px' : '-12px';
+      elJoystickCloseBtn.style.right = isFullscreen ? '20px' : '-12px';
+    }
+    if (elJoystickSizeBtn) {
+      elJoystickSizeBtn.textContent = sizeLabel;
+      elJoystickSizeBtn.style.top = isFullscreen ? '20px' : '-12px';
+      elJoystickSizeBtn.style.left = isFullscreen ? '20px' : '-12px';
+    }
+    if (elJoystickZoomUp) {
+      elJoystickZoomUp.style.top = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
+    }
+    if (elJoystickZoomDown) {
+      elJoystickZoomDown.style.bottom = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
+    }
+    const elJoystickLabel = document.getElementById('joystick-label');
+    if (elJoystickLabel) {
+      elJoystickLabel.style.marginTop = `${metrics.labelMargin}px`;
+      elJoystickLabel.style.fontSize = metrics.diameter >= 220 ? '0.85rem' : '0.75rem';
+    }
+  }
+
+  function setVirtualJoystickSize(size, options = {}) {
+    const nextSize = VIRTUAL_JOYSTICK_SIZE_ORDER.includes(size) ? size : 'normal';
+    state.virtualJoystick = normalizeVirtualJoystickSettings({
+      ...state.virtualJoystick,
+      size: nextSize,
+    });
+    applyVirtualJoystickLayout();
+    if (!options.skipUiSync && elVirtualJoystickSize) {
+      elVirtualJoystickSize.value = nextSize;
+    }
+    if (!options.skipSave) {
+      schedSave();
+    }
+  }
+
+  function cycleVirtualJoystickSize() {
+    const current = state.virtualJoystick?.size || 'normal';
+    const idx = VIRTUAL_JOYSTICK_SIZE_ORDER.indexOf(current);
+    const next = VIRTUAL_JOYSTICK_SIZE_ORDER[(idx + 1) % VIRTUAL_JOYSTICK_SIZE_ORDER.length];
+    setVirtualJoystickSize(next);
   }
 
   function showVirtualJoystick(show) {
@@ -3176,6 +3296,7 @@
     if (!show) {
       virtualJoystickTouchId = null;
       lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
+      pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       if (elJoystickCenter) {
         elJoystickCenter.style.transform = 'translate(-50%, -50%)';
@@ -3184,6 +3305,7 @@
     if (elVirtualJoystickContainer) {
       elVirtualJoystickContainer.style.display = show ? 'block' : 'none';
     }
+    if (show) applyVirtualJoystickLayout();
     updateJoystickButtonVisibility();
   }
 
@@ -3196,12 +3318,8 @@
   }
 
   if (elVirtualJoystick) {
-    const joystickRect = { x: 0, y: 0, size: 120, radius: 60 };
-
     function updateJoystickPosition(touchX, touchY) {
       const rect = elVirtualJoystick.getBoundingClientRect();
-      joystickRect.x = rect.left;
-      joystickRect.y = rect.top;
 
       const centerX = rect.left + rect.width / 2;
       const centerY = rect.top + rect.height / 2;
@@ -3210,7 +3328,8 @@
       let deltaY = touchY - centerY;
 
       const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-      const maxDistance = joystickRect.radius - 20;
+      const handleSize = elJoystickCenter.getBoundingClientRect().width || 40;
+      const maxDistance = Math.max(1, rect.width / 2 - handleSize / 2);
 
       if (distance > maxDistance) {
         const ratio = maxDistance / distance;
@@ -3240,8 +3359,8 @@
       pan = Math.round(pan * 10) / 10;
       tilt = Math.round(tilt * 10) / 10;
 
-      pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);
-      tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);
+      pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan, 'pan');
+      tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt, 'tilt');
       lastVirtualJoystickCommand = { pan, tilt };
 
       sendPtzDriveCommand(pan, tilt, 0, 'virtual');
@@ -3255,6 +3374,7 @@
     function resetJoystick() {
       elJoystickCenter.style.transform = 'translate(-50%, -50%)';
       lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
+      pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       console.debug('[PTZ] Virtual joystick reset to center');
     }
@@ -3302,6 +3422,13 @@
     });
   }
 
+  if (elJoystickSizeBtn) {
+    elJoystickSizeBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      cycleVirtualJoystickSize();
+    });
+  }
+
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState !== 'visible') {
       void stopPtzInput('system');
@@ -3311,6 +3438,7 @@
   window.addEventListener('pagehide', () => {
     void stopPtzInput('system');
   });
+  window.addEventListener('resize', applyVirtualJoystickLayout);
 
   // ── Virtual joystick button visibility ─────────────────────────────────────
   const isTouchDevice = window.matchMedia('(hover: none)').matches;
@@ -3318,8 +3446,9 @@
   function updateJoystickButtonVisibility() {
     if (!elVirtualJoystickBtn) return;
     const settingsPanelOpen = elGspPanel && elGspPanel.classList.contains('open');
+    const enabled = state.virtualJoystick?.enabled !== false;
     const joystickEnabled = localStorage.getItem('ptz-virtual-joystick') !== 'false';
-    const shouldShow = isTouchDevice && !virtualJoystickActive && !settingsPanelOpen && joystickEnabled;
+    const shouldShow = enabled && isTouchDevice && !virtualJoystickActive && !settingsPanelOpen && joystickEnabled;
     elVirtualJoystickBtn.style.display = shouldShow ? 'block' : 'none';
   }
 
@@ -3960,6 +4089,7 @@
 
   // Joystick settings elements
   const elVirtualJoystickEnabledCheckbox = document.getElementById('f-virtual-joystick-enabled');
+  const elVirtualJoystickSize = document.getElementById('f-virtual-joystick-size');
   const elJoystickEnabled = document.getElementById('f-joystick-enabled');
   const elJoystickModel = document.getElementById('f-joystick-model');
   const elJoystickDeadzone = document.getElementById('f-joystick-deadzone');
@@ -4073,17 +4203,19 @@
   elGspFill.addEventListener('change', saveGridSettings);
 
   function updateVirtualJoystickVisibility() {
-    const enabled = state.virtualJoystick?.enabled !== false;
-    const isTouchDevice = window.matchMedia('(hover: none)').matches;
-    if (elVirtualJoystickBtn) {
-      const show = enabled && isTouchDevice && localStorage.getItem('ptz-virtual-joystick') !== 'false';
-      elVirtualJoystickBtn.style.display = show ? 'block' : 'none';
+    state.virtualJoystick = normalizeVirtualJoystickSettings(state.virtualJoystick);
+    if (state.virtualJoystick.enabled === false && virtualJoystickActive) {
+      showVirtualJoystick(false);
     }
+    applyVirtualJoystickLayout();
+    updateJoystickButtonVisibility();
   }
 
   function loadJoystickSettings() {
+    state.virtualJoystick = normalizeVirtualJoystickSettings(state.virtualJoystick);
     const js = state.joystick = normalizeJoystickSettings(state.joystick);
     if (elVirtualJoystickEnabledCheckbox) elVirtualJoystickEnabledCheckbox.checked = state.virtualJoystick?.enabled !== false;
+    if (elVirtualJoystickSize) elVirtualJoystickSize.value = state.virtualJoystick?.size || 'normal';
     if (elJoystickEnabled) elJoystickEnabled.checked = !!js.enabled;
     if (elJoystickModel) elJoystickModel.value = js.model || 'logitech-extreme-3d';
     if (elJoystickDeadzone) {
@@ -4126,11 +4258,13 @@
       zoomCompensationCurve: elJoystickZoomComp?.value || 'linear',
     });
 
-    state.virtualJoystick = {
+    state.virtualJoystick = normalizeVirtualJoystickSettings({
+      ...state.virtualJoystick,
       enabled: elVirtualJoystickEnabledCheckbox?.checked !== false,
+      size: elVirtualJoystickSize?.value || state.virtualJoystick?.size || 'normal',
       deadzone: 0.35,
       sensitivity: { pan: 0.6, tilt: 0.6, zoom: 0.3 },
-    };
+    });
 
     if (wasEnabled && !state.joystick.enabled) {
       if (gamepadAnimationFrame) {
@@ -4173,6 +4307,10 @@
 
   if (elVirtualJoystickEnabledCheckbox) {
     elVirtualJoystickEnabledCheckbox.addEventListener('change', saveJoystickSettings);
+  }
+
+  if (elVirtualJoystickSize) {
+    elVirtualJoystickSize.addEventListener('change', saveJoystickSettings);
   }
 
   if (elJoystickEnabled) {

--- a/public/index.html
+++ b/public/index.html
@@ -3032,6 +3032,7 @@
 
   let virtualJoystickActive = false;
   let virtualJoystickTouchId = null;
+  let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
   const ptzDriveController = {
     desiredCommand: { pan: 0, tilt: 0, zoom: 0 },
     lastSentCommand: null,
@@ -3137,10 +3138,29 @@
     return sendPtzDriveCommand(0, 0, 0, source);
   }
 
+  function applyVirtualJoystickResponseCurve(value) {
+    const n = Math.max(-1, Math.min(1, Number(value) || 0));
+    if (!n) return 0;
+    return Math.sign(n) * Math.pow(Math.abs(n), 1.6);
+  }
+
+  function applyVirtualJoystickSnapbackGuard(next, previous) {
+    if (!next || !previous) return next;
+    if (Math.sign(next) !== Math.sign(previous)) {
+      const reverseGuard = Math.max(
+        0.25,
+        (state.virtualJoystick?.deadzone || 0.20) + 0.15
+      );
+      if (Math.abs(next) < reverseGuard) return 0;
+    }
+    return next;
+  }
+
   function showVirtualJoystick(show) {
     virtualJoystickActive = show;
     if (!show) {
       virtualJoystickTouchId = null;
+      lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       if (elJoystickCenter) {
         elJoystickCenter.style.transform = 'translate(-50%, -50%)';
@@ -3193,6 +3213,9 @@
       if (Math.abs(pan) < deadzone) pan = 0;
       if (Math.abs(tilt) < deadzone) tilt = 0;
 
+      pan = applyVirtualJoystickResponseCurve(pan);
+      tilt = applyVirtualJoystickResponseCurve(tilt);
+
       // Apply sensitivity from settings
       const sens = state.virtualJoystick?.sensitivity || { pan: 1.0, tilt: 1.0, zoom: 0.5 };
       pan *= (sens.pan || 1.0);
@@ -3202,12 +3225,21 @@
       pan = Math.round(pan * 10) / 10;
       tilt = Math.round(tilt * 10) / 10;
 
+      pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);
+      tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);
+      lastVirtualJoystickCommand = { pan, tilt };
+
       sendPtzDriveCommand(pan, tilt, 0, 'virtual');
-      console.debug('[PTZ] Virtual joystick:', { pan: pan.toFixed(2), tilt: tilt.toFixed(2), rawDistance: distance.toFixed(2) });
+      console.debug('[PTZ] Virtual joystick:', {
+        pan: pan.toFixed(2),
+        tilt: tilt.toFixed(2),
+        rawDistance: distance.toFixed(2),
+      });
     }
 
     function resetJoystick() {
       elJoystickCenter.style.transform = 'translate(-50%, -50%)';
+      lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       void stopPtzInput('virtual');
       console.debug('[PTZ] Virtual joystick reset to center');
     }

--- a/server.py
+++ b/server.py
@@ -141,6 +141,7 @@ DEFAULT_SETTINGS = {
     },
     "virtualJoystick": {
         "enabled": True,
+        "size": "normal",
         "deadzone": 0.25,
         "sensitivity": {
             "pan": 0.6,

--- a/server.py
+++ b/server.py
@@ -178,6 +178,53 @@ def _normalize_scan_wait_mode(wait_mode: str | None) -> str:
     return normalized if normalized in {"dwell", "settle"} else "settle"
 
 
+def _run_git_command(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", _HERE, *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _get_version_info() -> dict:
+    head_commit = _run_git_command(["rev-parse", "HEAD"])
+    short_commit = _run_git_command(["rev-parse", "--short", "HEAD"])
+    branch = _run_git_command(["branch", "--show-current"]) or "(detached)"
+    dirty_output = _run_git_command(["status", "--porcelain"])
+    dirty = bool(dirty_output)
+
+    local_default_ref = None
+    local_default_commit = None
+    for ref in ("origin/default", "default"):
+        ref_commit = _run_git_command(["rev-parse", ref])
+        if ref_commit:
+            local_default_ref = ref
+            local_default_commit = ref_commit
+            break
+
+    git_available = bool(head_commit and short_commit)
+    return {
+        "gitAvailable": git_available,
+        "branch": branch if git_available else None,
+        "commit": head_commit,
+        "shortCommit": short_commit,
+        "dirty": dirty if git_available else None,
+        "localDefaultRef": local_default_ref,
+        "localDefaultCommit": local_default_commit,
+        "headMatchesLocalDefault": (
+            head_commit == local_default_commit
+            if git_available and local_default_commit
+            else None
+        ),
+    }
+
+
 def _probe_recall_command_succeeded(result: ProbeResult) -> bool:
     if result.error is not None:
         return False
@@ -1746,6 +1793,8 @@ class Handler(BaseHTTPRequestHandler):
                     else "Playwright not installed. Run: pip install playwright && playwright install chromium",
                 },
             )
+        elif path == "/api/version":
+            self._json(200, _get_version_info())
         elif m := re.match(r"^/api/position/(\d+)$", path):
             self._get_position(int(m.group(1)))
         elif m := re.match(r"^/api/image/(\d+)/(\d+)/position$", path):

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -148,6 +148,14 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
 
+    def test_build_indicator_uses_version_endpoint(self):
+        self.assertIn("function applyBuildVersion(version)", self.html)
+        self.assertIn("fetch('/api/version')", self.html)
+        self.assertIn(
+            "elBuildCommit.title = `${branch} @ ${shortCommit} (${dirty}, ${defaultState})`;",
+            self.html,
+        )
+
     def test_joystick_state_is_normalized_and_visible(self):
         self.assertIn(
             'id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem"',

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -166,36 +166,66 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
         self.assertIn("function normalizeJoystickSettings(value)", self.html)
+        self.assertIn("function normalizeVirtualJoystickSettings(value)", self.html)
         self.assertIn("joystick: normalizeJoystickSettings(),", self.html)
+        self.assertIn("virtualJoystick: normalizeVirtualJoystickSettings(),", self.html)
         self.assertIn(
             "if (s.joystick) state.joystick = normalizeJoystickSettings(s.joystick);",
+            self.html,
+        )
+        self.assertIn(
+            "if (s.virtualJoystick) state.virtualJoystick = normalizeVirtualJoystickSettings(s.virtualJoystick);",
             self.html,
         )
         self.assertIn(
             "const js = state.joystick = normalizeJoystickSettings(state.joystick);",
             self.html,
         )
+        self.assertIn(
+            "state.virtualJoystick = normalizeVirtualJoystickSettings(state.virtualJoystick);",
+            self.html,
+        )
         self.assertIn("state.joystick = normalizeJoystickSettings({", self.html)
 
     def test_virtual_joystick_response_curve_and_snapback_guard_present(self):
         self.assertIn("let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };", self.html)
+        self.assertIn(
+            "let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };",
+            self.html,
+        )
         self.assertIn("function applyVirtualJoystickResponseCurve(value)", self.html)
         self.assertIn(
-            "return Math.sign(n) * Math.pow(Math.abs(n), 1.6);",
+            "return Math.sign(n) * Math.pow(Math.abs(n), 1.9);",
             self.html,
         )
         self.assertIn(
-            "function applyVirtualJoystickSnapbackGuard(next, previous)",
+            "function applyVirtualJoystickSnapbackGuard(next, previous, axis)",
             self.html,
         )
         self.assertIn(
-            "pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);",
+            "if (pendingVirtualJoystickDirection[axis] !== nextDirection) {",
             self.html,
         )
         self.assertIn(
-            "tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);",
+            "pendingVirtualJoystickDirection[axis] = nextDirection;",
             self.html,
         )
+        self.assertIn(
+            "pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan, 'pan');",
+            self.html,
+        )
+        self.assertIn(
+            "tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt, 'tilt');",
+            self.html,
+        )
+
+    def test_virtual_joystick_size_controls_present(self):
+        self.assertIn('id="f-virtual-joystick-size"', self.html)
+        self.assertIn('id="joystick-size-btn"', self.html)
+        self.assertIn("const VIRTUAL_JOYSTICK_SIZE_ORDER = ['normal', 'double', 'fullscreen'];", self.html)
+        self.assertIn("function applyVirtualJoystickLayout()", self.html)
+        self.assertIn("function cycleVirtualJoystickSize()", self.html)
+        self.assertIn("setVirtualJoystickSize(next);", self.html)
 
     def test_dpad_invalid_warn_is_deduplicated(self):
         # Deduplication guard variable is initialized to true (valid by default).

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -169,6 +169,26 @@ class TestFrontendContracts(unittest.TestCase):
         )
         self.assertIn("state.joystick = normalizeJoystickSettings({", self.html)
 
+    def test_virtual_joystick_response_curve_and_snapback_guard_present(self):
+        self.assertIn("let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };", self.html)
+        self.assertIn("function applyVirtualJoystickResponseCurve(value)", self.html)
+        self.assertIn(
+            "return Math.sign(n) * Math.pow(Math.abs(n), 1.6);",
+            self.html,
+        )
+        self.assertIn(
+            "function applyVirtualJoystickSnapbackGuard(next, previous)",
+            self.html,
+        )
+        self.assertIn(
+            "pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan);",
+            self.html,
+        )
+        self.assertIn(
+            "tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt);",
+            self.html,
+        )
+
     def test_dpad_invalid_warn_is_deduplicated(self):
         # Deduplication guard variable is initialized to true (valid by default).
         self.assertIn("let lastDpadValid = true;", self.html)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -835,6 +835,23 @@ class TestHTTPRoutes(unittest.TestCase):
         data = json.loads(body)
         self.assertIn("cameras", data)
 
+    def test_get_version_returns_git_metadata(self):
+        version_info = {
+            "gitAvailable": True,
+            "branch": "codex/test",
+            "commit": "abc123def456",
+            "shortCommit": "abc123d",
+            "dirty": False,
+            "localDefaultRef": "origin/default",
+            "localDefaultCommit": "fff111",
+            "headMatchesLocalDefault": False,
+        }
+        with patch("server._get_version_info", return_value=version_info):
+            status, body = self.srv.get("/api/version")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body), version_info)
+
     def test_post_settings_persists(self):
         payload = json.dumps({"activeCam": 2, "cameras": [], "labels": {}}).encode()
         status, body = self.srv.post("/settings", payload)


### PR DESCRIPTION
Superseded by #108, which contains the same joystick follow-up on a clean branch based on the current `default` head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual joystick now supports configurable sizing (normal, double, fullscreen modes) with a dedicated size toggle button.
  * Enhanced joystick responsiveness with improved control curve and direction stability.
  * Build indicator now displays enriched Git metadata (branch, commit status).

* **Tests**
  * Added comprehensive contract tests for build indicator version fetching and virtual joystick behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->