### PR TITLE
[codex] Harden joystick stop delivery

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3076,12 +3076,17 @@
   let virtualJoystickTouchId = null;
   let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
   let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
+  const PTZ_STOP_RETRY_COUNT = 2;
+  const PTZ_STOP_RETRY_INTERVAL_MS = 120;
   const ptzDriveController = {
     desiredCommand: { pan: 0, tilt: 0, zoom: 0 },
     lastSentCommand: null,
     inFlight: false,
     nextCommandId: Date.now(),
     activeInputSource: null,
+    retryStopNow: false,
+    stopRetryTimer: null,
+    stopResendRemaining: 0,
   };
 
   function quantizePtzAxis(value) {
@@ -3105,14 +3110,43 @@
     return !!command && command.pan === 0 && command.tilt === 0 && command.zoom === 0;
   }
 
+  function clearPtzStopRetryTimer() {
+    if (ptzDriveController.stopRetryTimer) {
+      clearTimeout(ptzDriveController.stopRetryTimer);
+      ptzDriveController.stopRetryTimer = null;
+    }
+  }
+
+  function schedulePtzStopRetry() {
+    clearPtzStopRetryTimer();
+    if (!ptzDriveController.stopResendRemaining || !isZeroPtzCommand(ptzDriveController.desiredCommand)) {
+      return;
+    }
+    ptzDriveController.stopRetryTimer = setTimeout(() => {
+      ptzDriveController.stopRetryTimer = null;
+      ptzDriveController.retryStopNow = true;
+      void flushPtzDriveController();
+    }, PTZ_STOP_RETRY_INTERVAL_MS);
+  }
+
   async function flushPtzDriveController() {
     if (ptzDriveController.inFlight) return true;
-    while (!ptzCommandsEqual(ptzDriveController.desiredCommand, ptzDriveController.lastSentCommand)) {
+    while (
+      !ptzCommandsEqual(ptzDriveController.desiredCommand, ptzDriveController.lastSentCommand)
+      || ptzDriveController.retryStopNow
+    ) {
       const next = clonePtzCommand(ptzDriveController.desiredCommand);
+      const isStopRetry = ptzDriveController.retryStopNow
+        && isZeroPtzCommand(next)
+        && ptzCommandsEqual(next, ptzDriveController.lastSentCommand);
+      ptzDriveController.retryStopNow = false;
       if (!isZeroPtzCommand(next) && isProtectedLiveCamera(state.activeCam)) {
         setStatus('error', 'Protected live camera is on ATEM program. Switch cameras or turn off Protect Live Camera before moving.');
         ptzDriveController.desiredCommand = { pan: 0, tilt: 0, zoom: 0 };
         ptzDriveController.activeInputSource = null;
+        ptzDriveController.retryStopNow = false;
+        ptzDriveController.stopResendRemaining = 0;
+        clearPtzStopRetryTimer();
         if (ptzCommandsEqual(ptzDriveController.desiredCommand, ptzDriveController.lastSentCommand)) {
           return false;
         }
@@ -3150,9 +3184,21 @@
             ptzDriveController.nextCommandId,
             lastCommandId + 1
           );
+          if (isStopRetry && ptzDriveController.stopResendRemaining > 0) {
+            ptzDriveController.stopResendRemaining -= 1;
+          }
+          schedulePtzStopRetry();
           continue;
         }
         ptzDriveController.lastSentCommand = next;
+        if (!isZeroPtzCommand(next)) {
+          ptzDriveController.retryStopNow = false;
+          ptzDriveController.stopResendRemaining = 0;
+          clearPtzStopRetryTimer();
+        } else if (isStopRetry && ptzDriveController.stopResendRemaining > 0) {
+          ptzDriveController.stopResendRemaining -= 1;
+        }
+        schedulePtzStopRetry();
         checkRecalledPresetForDrift();
       } catch (err) {
         setStatus('error', `PTZ move failed: ${err.message || err}`);
@@ -3166,12 +3212,22 @@
 
   function sendPtzDriveCommand(pan = 0, tilt = 0, zoom = 0, source = 'virtual') {
     const next = clonePtzCommand({ pan, tilt, zoom });
+    const wasMoving = !isZeroPtzCommand(ptzDriveController.desiredCommand)
+      || !isZeroPtzCommand(ptzDriveController.lastSentCommand);
     ptzDriveController.desiredCommand = next;
     if (isZeroPtzCommand(next)) {
+      if (wasMoving) {
+        ptzDriveController.retryStopNow = false;
+        ptzDriveController.stopResendRemaining = PTZ_STOP_RETRY_COUNT;
+        schedulePtzStopRetry();
+      }
       if (source === 'system' || source === ptzDriveController.activeInputSource) {
         ptzDriveController.activeInputSource = null;
       }
     } else {
+      ptzDriveController.retryStopNow = false;
+      ptzDriveController.stopResendRemaining = 0;
+      clearPtzStopRetryTimer();
       ptzDriveController.activeInputSource = source;
     }
     return flushPtzDriveController();

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -219,6 +219,16 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
 
+    def test_ptz_stop_retries_are_retained_after_centering(self):
+        self.assertIn("const PTZ_STOP_RETRY_COUNT = 2;", self.html)
+        self.assertIn("const PTZ_STOP_RETRY_INTERVAL_MS = 120;", self.html)
+        self.assertIn("stopResendRemaining: 0,", self.html)
+        self.assertIn("function clearPtzStopRetryTimer()", self.html)
+        self.assertIn("function schedulePtzStopRetry()", self.html)
+        self.assertIn("void flushPtzDriveController();", self.html)
+        self.assertIn("ptzDriveController.stopResendRemaining = PTZ_STOP_RETRY_COUNT;", self.html)
+        self.assertIn("schedulePtzStopRetry();", self.html)
+
     def test_virtual_joystick_size_controls_present(self):
         self.assertIn('id="f-virtual-joystick-size"', self.html)
         self.assertIn('id="joystick-size-btn"', self.html)


### PR DESCRIPTION
## What changed
- added a small stop retry mechanism in the PTZ drive controller so joystick center sends the initial stop plus two short follow-up stop commands
- kept normal movement deduplication in place so only centered stop commands are retried
- added frontend contract coverage for the stop retry behavior

## Why
The joystick could occasionally continue moving after returning to center because the frontend treated stop as a one-shot command. If that stop packet was missed, later centered frames were deduplicated and no reinforcing stop was sent.

## Impact
This makes physical and virtual joystick control safer in live operation by biasing toward an explicit stop after motion ends, without increasing normal movement traffic.

## Validation
- `ruff check server.py`
- `python -m py_compile server.py`
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PTZ (Pan-Tilt-Zoom) drive control reliability with an automatic retry mechanism to recover from transient state issues and ensure commands are properly executed.

* **Tests**
  * Added test coverage for PTZ stop retry functionality to verify proper behavior during controller state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/109)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->