### PR TITLE
[codex] Tune joystick stop and virtual deadzone

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1815,6 +1815,7 @@
       dpadMap: { up: 12, down: 13, left: 14, right: 15 },
     },
   };
+  const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.15;
 
   function normalizeJoystickSettings(value) {
     const joystick = value && typeof value === 'object' ? value : {};
@@ -1843,7 +1844,9 @@
   function normalizeVirtualJoystickSettings(value) {
     const virtual = value && typeof value === 'object' ? value : {};
     const size = ['normal', 'double', 'fullscreen'].includes(virtual.size) ? virtual.size : 'normal';
-    const deadzone = Number.isFinite(+virtual.deadzone) ? Math.max(0, Math.min(0.8, +virtual.deadzone)) : 0.25;
+    const deadzone = Number.isFinite(+virtual.deadzone)
+      ? Math.max(0, Math.min(0.8, +virtual.deadzone))
+      : DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;
     return {
       enabled: virtual.enabled !== false,
       size,
@@ -3076,7 +3079,7 @@
   let virtualJoystickTouchId = null;
   let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
   let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
-  const PTZ_STOP_RETRY_COUNT = 2;
+  const PTZ_STOP_RETRY_COUNT = 8;
   const PTZ_STOP_RETRY_INTERVAL_MS = 120;
   const ptzDriveController = {
     desiredCommand: { pan: 0, tilt: 0, zoom: 0 },
@@ -3399,7 +3402,7 @@
       let tilt = -(deltaY / maxDistance);
 
       // Apply deadzone from settings
-      const deadzone = state.virtualJoystick?.deadzone || 0.20;
+      const deadzone = state.virtualJoystick?.deadzone ?? DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;
       if (Math.abs(pan) < deadzone) pan = 0;
       if (Math.abs(tilt) < deadzone) tilt = 0;
 
@@ -4318,7 +4321,7 @@
       ...state.virtualJoystick,
       enabled: elVirtualJoystickEnabledCheckbox?.checked !== false,
       size: elVirtualJoystickSize?.value || state.virtualJoystick?.size || 'normal',
-      deadzone: 0.35,
+      deadzone: DEFAULT_VIRTUAL_JOYSTICK_DEADZONE,
       sensitivity: { pan: 0.6, tilt: 0.6, zoom: 0.3 },
     });
 

--- a/server.py
+++ b/server.py
@@ -142,7 +142,7 @@ DEFAULT_SETTINGS = {
     "virtualJoystick": {
         "enabled": True,
         "size": "normal",
-        "deadzone": 0.25,
+        "deadzone": 0.15,
         "sensitivity": {
             "pan": 0.6,
             "tilt": 0.6,

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -220,7 +220,7 @@ class TestFrontendContracts(unittest.TestCase):
         )
 
     def test_ptz_stop_retries_are_retained_after_centering(self):
-        self.assertIn("const PTZ_STOP_RETRY_COUNT = 2;", self.html)
+        self.assertIn("const PTZ_STOP_RETRY_COUNT = 8;", self.html)
         self.assertIn("const PTZ_STOP_RETRY_INTERVAL_MS = 120;", self.html)
         self.assertIn("stopResendRemaining: 0,", self.html)
         self.assertIn("function clearPtzStopRetryTimer()", self.html)
@@ -228,6 +228,12 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("void flushPtzDriveController();", self.html)
         self.assertIn("ptzDriveController.stopResendRemaining = PTZ_STOP_RETRY_COUNT;", self.html)
         self.assertIn("schedulePtzStopRetry();", self.html)
+
+    def test_virtual_joystick_deadzone_uses_smaller_default(self):
+        self.assertIn("const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.15;", self.html)
+        self.assertIn(": DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;", self.html)
+        self.assertIn("const deadzone = state.virtualJoystick?.deadzone ?? DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;", self.html)
+        self.assertIn("deadzone: DEFAULT_VIRTUAL_JOYSTICK_DEADZONE,", self.html)
 
     def test_virtual_joystick_size_controls_present(self):
         self.assertIn('id="f-virtual-joystick-size"', self.html)


### PR DESCRIPTION
## What changed
- lowered the virtual joystick default deadzone to `0.15`
- fixed joystick settings persistence so the virtual joystick no longer gets forced back to an oversized `0.35` deadzone
- extended centered PTZ stop retries from 2 to 8 so recentering reinforces stop for longer
- added frontend contract coverage for the smaller virtual joystick deadzone default

## Why
Operators reported two follow-up issues after the first stop-delivery fix: the virtual joystick still felt too insensitive around center, and the physical joystick could still occasionally coast after recentering. The oversized saved deadzone was making the touch joystick harder to control, and the stop retry window was still shorter than ideal for missed stop packets.

## Impact
This makes the virtual joystick respond earlier and keeps the live-safety bias toward explicit stop commands for a longer interval after the stick recenters.

## Validation
- `ruff check server.py`
- `python -m py_compile server.py`
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual joystick deadzone adjusted for improved input responsiveness
  * PTZ camera stop command reliability enhanced with improved retry behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->