### PR TITLE
[codex] Tune virtual joystick and add zoom hold

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1815,7 +1815,9 @@
       dpadMap: { up: 12, down: 13, left: 14, right: 15 },
     },
   };
-  const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.15;
+  const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.10;
+  const DEFAULT_VIRTUAL_JOYSTICK_RESPONSE_EXPONENT = 1.35;
+  const VIRTUAL_JOYSTICK_AXIS_STEP = 0.05;
 
   function normalizeJoystickSettings(value) {
     const joystick = value && typeof value === 'object' ? value : {};
@@ -3079,6 +3081,7 @@
   let virtualJoystickTouchId = null;
   let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
   let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
+  let virtualJoystickCommand = { pan: 0, tilt: 0, zoom: 0 };
   const PTZ_STOP_RETRY_COUNT = 8;
   const PTZ_STOP_RETRY_INTERVAL_MS = 120;
   const ptzDriveController = {
@@ -3243,7 +3246,7 @@
   function applyVirtualJoystickResponseCurve(value) {
     const n = Math.max(-1, Math.min(1, Number(value) || 0));
     if (!n) return 0;
-    return Math.sign(n) * Math.pow(Math.abs(n), 1.9);
+    return Math.sign(n) * Math.pow(Math.abs(n), DEFAULT_VIRTUAL_JOYSTICK_RESPONSE_EXPONENT);
   }
 
   function applyVirtualJoystickSnapbackGuard(next, previous, axis) {
@@ -3268,6 +3271,34 @@
   }
 
   const VIRTUAL_JOYSTICK_SIZE_ORDER = ['normal', 'double', 'fullscreen'];
+
+  function quantizeVirtualJoystickAxis(value) {
+    const n = Math.max(-1, Math.min(1, Number(value) || 0));
+    return Math.round(n / VIRTUAL_JOYSTICK_AXIS_STEP) * VIRTUAL_JOYSTICK_AXIS_STEP;
+  }
+
+  function sendVirtualJoystickCommand(pan = virtualJoystickCommand.pan, tilt = virtualJoystickCommand.tilt, zoom = virtualJoystickCommand.zoom) {
+    virtualJoystickCommand = {
+      pan: quantizeVirtualJoystickAxis(pan),
+      tilt: quantizeVirtualJoystickAxis(tilt),
+      zoom: quantizeVirtualJoystickAxis(zoom),
+    };
+    return sendPtzDriveCommand(
+      virtualJoystickCommand.pan,
+      virtualJoystickCommand.tilt,
+      virtualJoystickCommand.zoom,
+      'virtual'
+    );
+  }
+
+  function stopVirtualJoystickZoom() {
+    return sendVirtualJoystickCommand(virtualJoystickCommand.pan, virtualJoystickCommand.tilt, 0);
+  }
+
+  function setVirtualJoystickZoom(direction) {
+    const zoom = Math.max(-1, Math.min(1, Number(direction) || 0));
+    return sendVirtualJoystickCommand(virtualJoystickCommand.pan, virtualJoystickCommand.tilt, zoom);
+  }
 
   function getVirtualJoystickMetrics() {
     const size = state.virtualJoystick?.size || 'normal';
@@ -3316,9 +3347,11 @@
       elJoystickSizeBtn.style.left = isFullscreen ? '20px' : '-12px';
     }
     if (elJoystickZoomUp) {
+      elJoystickZoomUp.style.display = 'block';
       elJoystickZoomUp.style.top = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
     }
     if (elJoystickZoomDown) {
+      elJoystickZoomDown.style.display = 'block';
       elJoystickZoomDown.style.bottom = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
     }
     const elJoystickLabel = document.getElementById('joystick-label');
@@ -3356,6 +3389,7 @@
       virtualJoystickTouchId = null;
       lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
+      virtualJoystickCommand = { pan: 0, tilt: 0, zoom: 0 };
       void stopPtzInput('virtual');
       if (elJoystickCenter) {
         elJoystickCenter.style.transform = 'translate(-50%, -50%)';
@@ -3414,15 +3448,15 @@
       pan *= (sens.pan || 1.0);
       tilt *= (sens.tilt || 1.0);
 
-      // Quantize to 0.1 step to avoid float precision issues
-      pan = Math.round(pan * 10) / 10;
-      tilt = Math.round(tilt * 10) / 10;
+      // Quantize virtual touch input more finely than the physical stick.
+      pan = quantizeVirtualJoystickAxis(pan);
+      tilt = quantizeVirtualJoystickAxis(tilt);
 
       pan = applyVirtualJoystickSnapbackGuard(pan, lastVirtualJoystickCommand.pan, 'pan');
       tilt = applyVirtualJoystickSnapbackGuard(tilt, lastVirtualJoystickCommand.tilt, 'tilt');
       lastVirtualJoystickCommand = { pan, tilt };
 
-      sendPtzDriveCommand(pan, tilt, 0, 'virtual');
+      sendVirtualJoystickCommand(pan, tilt, virtualJoystickCommand.zoom);
       console.debug('[PTZ] Virtual joystick:', {
         pan: pan.toFixed(2),
         tilt: tilt.toFixed(2),
@@ -3434,6 +3468,7 @@
       elJoystickCenter.style.transform = 'translate(-50%, -50%)';
       lastVirtualJoystickCommand = { pan: 0, tilt: 0 };
       pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };
+      virtualJoystickCommand = { pan: 0, tilt: 0, zoom: 0 };
       void stopPtzInput('virtual');
       console.debug('[PTZ] Virtual joystick reset to center');
     }
@@ -3487,6 +3522,28 @@
       cycleVirtualJoystickSize();
     });
   }
+
+  function bindVirtualJoystickZoomButton(el, direction) {
+    if (!el) return;
+    const start = (e) => {
+      e.preventDefault();
+      void setVirtualJoystickZoom(direction);
+    };
+    const stop = (e) => {
+      e.preventDefault();
+      void stopVirtualJoystickZoom();
+    };
+    el.addEventListener('pointerdown', start);
+    el.addEventListener('pointerup', stop);
+    el.addEventListener('pointercancel', stop);
+    el.addEventListener('lostpointercapture', stop);
+    el.addEventListener('pointerleave', (e) => {
+      if (e.buttons) stop(e);
+    });
+  }
+
+  bindVirtualJoystickZoomButton(elJoystickZoomUp, 0.5);
+  bindVirtualJoystickZoomButton(elJoystickZoomDown, -0.5);
 
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState !== 'visible') {

--- a/server.py
+++ b/server.py
@@ -142,7 +142,7 @@ DEFAULT_SETTINGS = {
     "virtualJoystick": {
         "enabled": True,
         "size": "normal",
-        "deadzone": 0.15,
+        "deadzone": 0.10,
         "sensitivity": {
             "pan": 0.6,
             "tilt": 0.6,

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -193,11 +193,14 @@ class TestFrontendContracts(unittest.TestCase):
             "let pendingVirtualJoystickDirection = { pan: 0, tilt: 0 };",
             self.html,
         )
+        self.assertIn("const DEFAULT_VIRTUAL_JOYSTICK_RESPONSE_EXPONENT = 1.35;", self.html)
+        self.assertIn("const VIRTUAL_JOYSTICK_AXIS_STEP = 0.05;", self.html)
         self.assertIn("function applyVirtualJoystickResponseCurve(value)", self.html)
         self.assertIn(
-            "return Math.sign(n) * Math.pow(Math.abs(n), 1.9);",
+            "return Math.sign(n) * Math.pow(Math.abs(n), DEFAULT_VIRTUAL_JOYSTICK_RESPONSE_EXPONENT);",
             self.html,
         )
+        self.assertIn("function quantizeVirtualJoystickAxis(value)", self.html)
         self.assertIn(
             "function applyVirtualJoystickSnapbackGuard(next, previous, axis)",
             self.html,
@@ -230,10 +233,22 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("schedulePtzStopRetry();", self.html)
 
     def test_virtual_joystick_deadzone_uses_smaller_default(self):
-        self.assertIn("const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.15;", self.html)
+        self.assertIn("const DEFAULT_VIRTUAL_JOYSTICK_DEADZONE = 0.10;", self.html)
         self.assertIn(": DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;", self.html)
         self.assertIn("const deadzone = state.virtualJoystick?.deadzone ?? DEFAULT_VIRTUAL_JOYSTICK_DEADZONE;", self.html)
         self.assertIn("deadzone: DEFAULT_VIRTUAL_JOYSTICK_DEADZONE,", self.html)
+
+    def test_virtual_joystick_zoom_buttons_drive_combined_command(self):
+        self.assertIn("let virtualJoystickCommand = { pan: 0, tilt: 0, zoom: 0 };", self.html)
+        self.assertIn("function sendVirtualJoystickCommand(", self.html)
+        self.assertIn("function stopVirtualJoystickZoom()", self.html)
+        self.assertIn("function setVirtualJoystickZoom(direction)", self.html)
+        self.assertIn("elJoystickZoomUp.style.display = 'block';", self.html)
+        self.assertIn("elJoystickZoomDown.style.display = 'block';", self.html)
+        self.assertIn("sendVirtualJoystickCommand(pan, tilt, virtualJoystickCommand.zoom);", self.html)
+        self.assertIn("function bindVirtualJoystickZoomButton(el, direction)", self.html)
+        self.assertIn("bindVirtualJoystickZoomButton(elJoystickZoomUp, 0.5);", self.html)
+        self.assertIn("bindVirtualJoystickZoomButton(elJoystickZoomDown, -0.5);", self.html)
 
     def test_virtual_joystick_size_controls_present(self):
         self.assertIn('id="f-virtual-joystick-size"', self.html)


### PR DESCRIPTION
## What changed
- lowered the virtual joystick default deadzone again to `0.10`
- softened the virtual joystick response curve and tightened touch quantization for earlier, smoother movement near center
- wired the existing `+` and `-` virtual joystick buttons as press-and-hold zoom controls
- routed zoom through a combined virtual joystick PTZ command so zoom can coexist with pan/tilt instead of replacing it
- added frontend contract coverage for the updated virtual joystick tuning and zoom button behavior

## Why
The virtual joystick was still feeling too soft around center even after the previous deadzone reduction, and touch operators needed a simple way to zoom without giving up fine pan/tilt framing. This pass makes touch control engage sooner and exposes a clear live-safe zoom affordance.

## Impact
Touch operators can frame more precisely near center and can hold `+` or `-` to zoom while continuing to pan and tilt.

## Validation
- `ruff check server.py`
- `python -m py_compile server.py`
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Virtual joystick now includes integrated discrete zoom control alongside pan/tilt operations
  * Zoom control buttons are explicitly displayed and interactive during joystick operation

* **Improvements**
  * Enhanced joystick responsiveness with optimized default response curve and settings
  * Improved input precision with refined deadzone sensitivity and axis quantization handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/111)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->