### PR TITLE
[codex] Reposition virtual joystick zoom buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1775,8 +1775,8 @@
     <div style="position:absolute; width:100%; height:100%; border:1px dashed var(--border); border-radius:50%; opacity:0.3;"></div>
   </div>
   <div id="joystick-label" style="text-align:center; margin-top:8px; font-size:0.75rem; color:var(--muted); white-space:nowrap;">Pan/Tilt</div>
-  <button id="joystick-zoom-up" style="position:absolute; top:-40px; left:50%; transform:translateX(-50%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">+</button>
-  <button id="joystick-zoom-down" style="position:absolute; bottom:-40px; left:50%; transform:translateX(-50%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">−</button>
+  <button id="joystick-zoom-up" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(-110%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">+</button>
+  <button id="joystick-zoom-down" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(10%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">−</button>
 </div>
 
 <!-- Virtual Joystick Toggle Button -->
@@ -3303,14 +3303,14 @@
   function getVirtualJoystickMetrics() {
     const size = state.virtualJoystick?.size || 'normal';
     if (size === 'double') {
-      return { diameter: 240, handle: 72, zoomOffset: 52, labelMargin: 10 };
+      return { diameter: 240, handle: 72, zoomInset: 12, zoomGap: 10, labelMargin: 10 };
     }
     if (size === 'fullscreen') {
       const diameter = Math.max(220, Math.min(window.innerWidth, window.innerHeight) - 64);
       const handle = Math.max(56, Math.min(96, Math.round(diameter * 0.3)));
-      return { diameter, handle, zoomOffset: 64, labelMargin: 14 };
+      return { diameter, handle, zoomInset: 24, zoomGap: 12, labelMargin: 14 };
     }
-    return { diameter: 120, handle: 40, zoomOffset: 40, labelMargin: 8 };
+    return { diameter: 120, handle: 40, zoomInset: 12, zoomGap: 8, labelMargin: 8 };
   }
 
   function applyVirtualJoystickLayout() {
@@ -3326,7 +3326,7 @@
     elVirtualJoystickContainer.style.right = 'auto';
     elVirtualJoystickContainer.style.bottom = isFullscreen ? '0' : '20px';
     elVirtualJoystickContainer.style.left = isFullscreen ? '0' : '20px';
-    elVirtualJoystickContainer.style.width = isFullscreen ? '100vw' : `${metrics.diameter}px`;
+    elVirtualJoystickContainer.style.width = isFullscreen ? '100vw' : `${metrics.diameter + 48}px`;
     elVirtualJoystickContainer.style.height = isFullscreen ? '100vh' : 'auto';
     elVirtualJoystickContainer.style.background = isFullscreen ? 'rgba(5, 15, 24, 0.22)' : 'transparent';
 
@@ -3348,11 +3348,17 @@
     }
     if (elJoystickZoomUp) {
       elJoystickZoomUp.style.display = 'block';
-      elJoystickZoomUp.style.top = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
+      elJoystickZoomUp.style.left = isFullscreen ? `calc(50% + ${Math.round(metrics.diameter / 2) + metrics.zoomInset}px)` : `${metrics.diameter + metrics.zoomInset}px`;
+      elJoystickZoomUp.style.top = isFullscreen ? '50%' : '50%';
+      elJoystickZoomUp.style.bottom = 'auto';
+      elJoystickZoomUp.style.transform = `translateY(calc(-100% - ${metrics.zoomGap / 2}px))`;
     }
     if (elJoystickZoomDown) {
       elJoystickZoomDown.style.display = 'block';
-      elJoystickZoomDown.style.bottom = isFullscreen ? `${Math.max(24, overlaySpace - metrics.zoomOffset + 36)}px` : `-${metrics.zoomOffset}px`;
+      elJoystickZoomDown.style.left = isFullscreen ? `calc(50% + ${Math.round(metrics.diameter / 2) + metrics.zoomInset}px)` : `${metrics.diameter + metrics.zoomInset}px`;
+      elJoystickZoomDown.style.top = isFullscreen ? '50%' : '50%';
+      elJoystickZoomDown.style.bottom = 'auto';
+      elJoystickZoomDown.style.transform = `translateY(${metrics.zoomGap / 2}px)`;
     }
     const elJoystickLabel = document.getElementById('joystick-label');
     if (elJoystickLabel) {


### PR DESCRIPTION
## What changed
- moved the virtual joystick zoom buttons from above/below the joystick to a right-side vertical stack
- widened the non-fullscreen virtual joystick overlay footprint so the side-mounted zoom controls remain inside the visible touch surface area
- updated the layout math for normal, double, and fullscreen joystick modes so the zoom controls stay visible instead of landing below the viewport

## Why
The `+` and `−` zoom controls were being positioned relative to a bottom-anchored joystick overlay, which could place the lower button off-screen on smaller layouts. Operators reported that the zoom buttons were not visible even though the zoom feature was already wired.

## Impact
Touch operators should now see both zoom controls consistently when the virtual joystick is open.

## Validation
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned virtual joystick zoom controls from overlay placement (top/bottom) to right-side positioning for improved visibility and control accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->