### PR TITLE
[codex] Enlarge virtual joystick zoom targets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1775,8 +1775,8 @@
     <div style="position:absolute; width:100%; height:100%; border:1px dashed var(--border); border-radius:50%; opacity:0.3;"></div>
   </div>
   <div id="joystick-label" style="text-align:center; margin-top:8px; font-size:0.75rem; color:var(--muted); white-space:nowrap;">Pan/Tilt</div>
-  <button id="joystick-zoom-up" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(-110%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">+</button>
-  <button id="joystick-zoom-down" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(10%); width:32px; height:32px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:4px; font-size:18px; cursor:pointer; display:none;">−</button>
+  <button id="joystick-zoom-up" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(-110%); width:44px; height:44px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:10px; font-size:24px; font-weight:700; line-height:1; cursor:pointer; display:none;">+</button>
+  <button id="joystick-zoom-down" style="position:absolute; top:50%; left:calc(100% + 12px); transform:translateY(10%); width:44px; height:44px; padding:0; border:1px solid var(--border); background:var(--surf2); color:var(--accent); border-radius:10px; font-size:24px; font-weight:700; line-height:1; cursor:pointer; display:none;">−</button>
 </div>
 
 <!-- Virtual Joystick Toggle Button -->
@@ -3303,14 +3303,14 @@
   function getVirtualJoystickMetrics() {
     const size = state.virtualJoystick?.size || 'normal';
     if (size === 'double') {
-      return { diameter: 240, handle: 72, zoomInset: 12, zoomGap: 10, labelMargin: 10 };
+      return { diameter: 240, handle: 72, zoomInset: 14, zoomGap: 12, zoomButtonSize: 56, zoomFontSize: 30, labelMargin: 10 };
     }
     if (size === 'fullscreen') {
       const diameter = Math.max(220, Math.min(window.innerWidth, window.innerHeight) - 64);
       const handle = Math.max(56, Math.min(96, Math.round(diameter * 0.3)));
-      return { diameter, handle, zoomInset: 24, zoomGap: 12, labelMargin: 14 };
+      return { diameter, handle, zoomInset: 24, zoomGap: 14, zoomButtonSize: 64, zoomFontSize: 36, labelMargin: 14 };
     }
-    return { diameter: 120, handle: 40, zoomInset: 12, zoomGap: 8, labelMargin: 8 };
+    return { diameter: 120, handle: 40, zoomInset: 12, zoomGap: 10, zoomButtonSize: 44, zoomFontSize: 24, labelMargin: 8 };
   }
 
   function applyVirtualJoystickLayout() {
@@ -3326,7 +3326,7 @@
     elVirtualJoystickContainer.style.right = 'auto';
     elVirtualJoystickContainer.style.bottom = isFullscreen ? '0' : '20px';
     elVirtualJoystickContainer.style.left = isFullscreen ? '0' : '20px';
-    elVirtualJoystickContainer.style.width = isFullscreen ? '100vw' : `${metrics.diameter + 48}px`;
+    elVirtualJoystickContainer.style.width = isFullscreen ? '100vw' : `${metrics.diameter + metrics.zoomInset + metrics.zoomButtonSize}px`;
     elVirtualJoystickContainer.style.height = isFullscreen ? '100vh' : 'auto';
     elVirtualJoystickContainer.style.background = isFullscreen ? 'rgba(5, 15, 24, 0.22)' : 'transparent';
 
@@ -3348,6 +3348,9 @@
     }
     if (elJoystickZoomUp) {
       elJoystickZoomUp.style.display = 'block';
+      elJoystickZoomUp.style.width = `${metrics.zoomButtonSize}px`;
+      elJoystickZoomUp.style.height = `${metrics.zoomButtonSize}px`;
+      elJoystickZoomUp.style.fontSize = `${metrics.zoomFontSize}px`;
       elJoystickZoomUp.style.left = isFullscreen ? `calc(50% + ${Math.round(metrics.diameter / 2) + metrics.zoomInset}px)` : `${metrics.diameter + metrics.zoomInset}px`;
       elJoystickZoomUp.style.top = isFullscreen ? '50%' : '50%';
       elJoystickZoomUp.style.bottom = 'auto';
@@ -3355,6 +3358,9 @@
     }
     if (elJoystickZoomDown) {
       elJoystickZoomDown.style.display = 'block';
+      elJoystickZoomDown.style.width = `${metrics.zoomButtonSize}px`;
+      elJoystickZoomDown.style.height = `${metrics.zoomButtonSize}px`;
+      elJoystickZoomDown.style.fontSize = `${metrics.zoomFontSize}px`;
       elJoystickZoomDown.style.left = isFullscreen ? `calc(50% + ${Math.round(metrics.diameter / 2) + metrics.zoomInset}px)` : `${metrics.diameter + metrics.zoomInset}px`;
       elJoystickZoomDown.style.top = isFullscreen ? '50%' : '50%';
       elJoystickZoomDown.style.bottom = 'auto';

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -250,6 +250,15 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("bindVirtualJoystickZoomButton(elJoystickZoomUp, 0.5);", self.html)
         self.assertIn("bindVirtualJoystickZoomButton(elJoystickZoomDown, -0.5);", self.html)
 
+    def test_virtual_joystick_zoom_buttons_use_mobile_friendly_sizes(self):
+        self.assertIn("width:44px; height:44px;", self.html)
+        self.assertIn("font-size:24px;", self.html)
+        self.assertIn("zoomButtonSize: 44, zoomFontSize: 24", self.html)
+        self.assertIn("zoomButtonSize: 56, zoomFontSize: 30", self.html)
+        self.assertIn("zoomButtonSize: 64, zoomFontSize: 36", self.html)
+        self.assertIn("elJoystickZoomUp.style.width = `${metrics.zoomButtonSize}px`;", self.html)
+        self.assertIn("elJoystickZoomDown.style.width = `${metrics.zoomButtonSize}px`;", self.html)
+
     def test_virtual_joystick_size_controls_present(self):
         self.assertIn('id="f-virtual-joystick-size"', self.html)
         self.assertIn('id="joystick-size-btn"', self.html)


### PR DESCRIPTION
## What changed
- increased the virtual joystick zoom buttons to mobile-friendly touch target sizes
- scaled the zoom controls by joystick mode so double and fullscreen layouts get even larger targets
- widened the non-fullscreen joystick overlay footprint to fit the larger side-mounted zoom controls
- added frontend contract coverage for the new zoom target sizing

## Why
Operators reported that the zoom buttons were visible but still too small and hard to press reliably on mobile. This pass makes the controls easier to hit with a thumb while preserving the current joystick layout.

## Impact
Touch operators should be able to press and hold the zoom controls more reliably on phones and tablets.

## Validation
- `uv run pytest tests/test_frontend_contracts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enlarged virtual joystick zoom buttons with improved dimensions and spacing.
  * Optimized zoom control layout for enhanced mobile usability.

* **Tests**
  * Added test coverage for virtual joystick zoom button sizing validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->