### PR TITLE
Restore settle polling for PTZ autocut recalls

### DIFF
--- a/server.py
+++ b/server.py
@@ -303,7 +303,7 @@ def recall_visca_preset(
         stable_count=VISCA_STABLE_COUNT,
         inquiry_timeout=VISCA_INQUIRY_TIMEOUT_S,
         include_focus=False,
-        require_settle=wait_mode == "settle",
+        require_settle=wait_mode in ("settle", "autocut"),
         verbose=False,
     )
     success = (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1828,11 +1828,11 @@ class TestRecallViscaPresetEdgeCases(unittest.TestCase):
             server.recall_visca_preset("10.0.0.1", 52381, 1, 1, wait_mode="dwell")
         self.assertFalse(mock_probe.call_args.kwargs["require_settle"])
 
-    def test_autocut_mode_sets_require_settle_false(self):
+    def test_autocut_mode_sets_require_settle_true(self):
         probe_result = self._make_probe_result(saw_completion=True)
         with patch("server._probe_preset", return_value=probe_result) as mock_probe:
             server.recall_visca_preset("10.0.0.1", 52381, 1, 1, wait_mode="autocut")
-        self.assertFalse(mock_probe.call_args.kwargs["require_settle"])
+        self.assertTrue(mock_probe.call_args.kwargs["require_settle"])
 
     def test_settle_mode_sets_require_settle_true(self):
         probe_result = self._make_probe_result(settled=True)


### PR DESCRIPTION
## Summary
- Re-enable motion settle polling for `waitMode="autocut"` recalls so Auto Cut can trigger as soon as the camera actually stops.
- Preserve the existing VISCA completion fast path and the fallback max-timer behavior when neither confirmation signal arrives.
- Update the server regression test to lock in the restored `autocut` settle behavior.

## Testing
- Lint and bytecode checks passed.
- Targeted pytest coverage for autocut/recall behavior passed.
- Frontend contract tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VISCA preset recall behavior to ensure proper handling in autocut mode, providing consistent behavior between autocut and settle modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->