### PR TITLE
Fix PTZ autocut fallback timing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4171,19 +4171,30 @@
     if (!autoCutPlan || !autoCutPlan.source) return;
     clearPendingAutoCut();
     const { source, camName, delayMs } = autoCutPlan;
-    if (delayMs > 0) {
+    const usingCompletionFallback = trigger === 'completion';
+    const usingTimeoutFallback = trigger === 'timeout';
+    const effectiveDelayMs = usingTimeoutFallback
+      ? Math.max(0, delayMs - Math.max(0, recallElapsedMs || 0))
+      : 0;
+    if (effectiveDelayMs > 0) {
       autoCutPending = { source, camName, preset };
       setAutoCutDebug(`WAIT ${source}`);
-      setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} after confirmed stop + ${(delayMs / 1000).toFixed(1).replace(/\.0$/, '')}s`, false);
+      const delayLabel = (effectiveDelayMs / 1000).toFixed(2).replace(/\.?0+$/, '');
+      setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} waiting up to ${delayLabel}s more for fallback max`, false);
       autoCutTimer = setTimeout(() => {
         const pending = autoCutPending;
         if (!pending) return;
         fireAutoCut(pending.source, pending.camName, pending.preset);
-      }, delayMs);
+      }, effectiveDelayMs);
       return;
     }
     setAutoCutDebug(`READY ${source}`);
-    setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} when camera stop is confirmed`, false);
+    const readyReason = usingCompletionFallback
+      ? 'on VISCA completion'
+      : usingTimeoutFallback
+        ? 'on fallback max timeout'
+        : 'when camera stop is confirmed';
+    setStatus('busy', `Auto Cut armed: ${camName} preset ${preset} ${readyReason}`, false);
     void fireAutoCut(source, camName, preset);
   }
 

--- a/scripts/av1281_motion_probe.py
+++ b/scripts/av1281_motion_probe.py
@@ -363,6 +363,8 @@ def probe_preset(
     if local_port is None and transport == "sony-udp":
         local_port = port
     samples: list[MotionSample] = []
+    replies: list[ViscaReply] = []
+    saw_completion = False
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -459,10 +461,22 @@ def probe_preset(
     except Exception as exc:
         if verbose:
             print(f"Probe failed: {exc}")
+        # Preserve a confirmed VISCA completion if settle polling fails later.
+        # This keeps autocut mode able to fall back to completion without
+        # masking true send/completion-path failures where no completion arrived.
+        if saw_completion:
+            return ProbeResult(
+                preset=preset,
+                replies=replies,
+                saw_completion=saw_completion,
+                settled=False,
+                samples=samples,
+                error=None,
+            )
         return ProbeResult(
             preset=preset,
-            replies=[],
-            saw_completion=False,
+            replies=replies,
+            saw_completion=saw_completion,
             settled=False,
             samples=samples,
             error=str(exc),

--- a/server.py
+++ b/server.py
@@ -303,7 +303,7 @@ def recall_visca_preset(
         stable_count=VISCA_STABLE_COUNT,
         inquiry_timeout=VISCA_INQUIRY_TIMEOUT_S,
         include_focus=False,
-        require_settle=wait_mode == "settle",
+        require_settle=wait_mode in ("settle", "autocut"),
         verbose=False,
     )
     success = (

--- a/tests/test_av1281_motion_probe.py
+++ b/tests/test_av1281_motion_probe.py
@@ -72,5 +72,101 @@ class TestSendInquiry(unittest.TestCase):
         self.assertIn("saw 9041ff", str(ctx.exception))
 
 
+class _FakeProbeSocket:
+    def bind(self, _addr):
+        return None
+
+    def settimeout(self, _timeout):
+        return None
+
+    def getsockname(self):
+        return ("0.0.0.0", 52381)
+
+    def close(self):
+        return None
+
+
+class TestProbePreset(unittest.TestCase):
+    def test_preserves_completion_when_settle_polling_fails(self):
+        completion = probe.ViscaReply("completion", 0x90, 0x51, b"\x90\x51\xff", 1)
+
+        with (
+            patch("socket.socket", return_value=_FakeProbeSocket()),
+            patch("scripts.av1281_motion_probe.send_command"),
+            patch(
+                "scripts.av1281_motion_probe.wait_for_completion",
+                return_value=([completion], True),
+            ),
+            patch(
+                "scripts.av1281_motion_probe.query_motion_sample",
+                side_effect=TimeoutError("inquiry timeout"),
+            ),
+            patch(
+                "scripts.av1281_motion_probe.time.monotonic",
+                side_effect=[0.0, 0.0, 0.0],
+            ),
+        ):
+            result = probe.probe_preset(
+                ip="10.0.0.1",
+                port=52381,
+                camera_address=1,
+                preset=5,
+                transport="sony-udp",
+                local_port=None,
+                completion_timeout=2.0,
+                settle_timeout=8.0,
+                poll_interval=0.2,
+                stable_count=3,
+                inquiry_timeout=1.0,
+                include_focus=False,
+                require_settle=True,
+                verbose=False,
+            )
+
+        self.assertTrue(result.saw_completion)
+        self.assertEqual(result.replies, [completion])
+        self.assertFalse(result.settled)
+        self.assertIsNone(result.error)
+
+    def test_reports_error_when_no_completion_arrived_before_polling_failure(self):
+        with (
+            patch("socket.socket", return_value=_FakeProbeSocket()),
+            patch("scripts.av1281_motion_probe.send_command"),
+            patch(
+                "scripts.av1281_motion_probe.wait_for_completion",
+                return_value=([], False),
+            ),
+            patch(
+                "scripts.av1281_motion_probe.query_motion_sample",
+                side_effect=TimeoutError("inquiry timeout"),
+            ),
+            patch(
+                "scripts.av1281_motion_probe.time.monotonic",
+                side_effect=[0.0, 0.0, 0.0],
+            ),
+        ):
+            result = probe.probe_preset(
+                ip="10.0.0.1",
+                port=52381,
+                camera_address=1,
+                preset=5,
+                transport="sony-udp",
+                local_port=None,
+                completion_timeout=2.0,
+                settle_timeout=8.0,
+                poll_interval=0.2,
+                stable_count=3,
+                inquiry_timeout=1.0,
+                include_focus=False,
+                require_settle=True,
+                verbose=False,
+            )
+
+        self.assertFalse(result.saw_completion)
+        self.assertEqual(result.replies, [])
+        self.assertFalse(result.settled)
+        self.assertEqual(result.error, "inquiry timeout")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -156,6 +156,32 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
 
+    def test_auto_cut_uses_trigger_to_skip_fallback_delay(self):
+        self.assertIn(
+            "const usingCompletionFallback = trigger === 'completion';",
+            self.html,
+        )
+        self.assertIn(
+            "const usingTimeoutFallback = trigger === 'timeout';",
+            self.html,
+        )
+        self.assertIn(
+            "const effectiveDelayMs = usingTimeoutFallback",
+            self.html,
+        )
+        self.assertIn(
+            "waiting up to ${delayLabel}s more for fallback max",
+            self.html,
+        )
+        self.assertIn(
+            "? 'on VISCA completion'",
+            self.html,
+        )
+        self.assertIn(
+            "? 'on fallback max timeout'",
+            self.html,
+        )
+
     def test_joystick_state_is_normalized_and_visible(self):
         self.assertIn(
             'id="joystick-settings-section" class="gsp-extra-card gsp-mobile-section active" data-mobile-tab="atem"',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1828,11 +1828,11 @@ class TestRecallViscaPresetEdgeCases(unittest.TestCase):
             server.recall_visca_preset("10.0.0.1", 52381, 1, 1, wait_mode="dwell")
         self.assertFalse(mock_probe.call_args.kwargs["require_settle"])
 
-    def test_autocut_mode_sets_require_settle_false(self):
+    def test_autocut_mode_sets_require_settle_true(self):
         probe_result = self._make_probe_result(saw_completion=True)
         with patch("server._probe_preset", return_value=probe_result) as mock_probe:
             server.recall_visca_preset("10.0.0.1", 52381, 1, 1, wait_mode="autocut")
-        self.assertFalse(mock_probe.call_args.kwargs["require_settle"])
+        self.assertTrue(mock_probe.call_args.kwargs["require_settle"])
 
     def test_settle_mode_sets_require_settle_true(self):
         probe_result = self._make_probe_result(settled=True)


### PR DESCRIPTION
## Summary
- fix autocut UI timing so settle and completion triggers cut immediately
- preserve VISCA completion fallback if settle polling fails after completion
- add regression coverage for the frontend timing and probe fallback paths

## Testing
- uv run pytest tests/test_av1281_motion_probe.py
- uv run pytest tests/test_server.py -k "autocut or recall"
- uv run pytest tests/test_frontend_contracts.py
- ruff check server.py scripts/av1281_motion_probe.py tests/test_av1281_motion_probe.py tests/test_frontend_contracts.py
- python -m py_compile server.py scripts/av1281_motion_probe.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced auto-cut logic supporting two distinct fallback triggers—VISCA completion and timeout—with intelligent delay recalculation.
  * Improved status messaging displaying specific wait durations during fallback scenarios.

* **Bug Fixes**
  * Improved state preservation and error handling during camera communication operations.

* **Tests**
  * Added comprehensive test coverage for auto-cut trigger behavior and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/118)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->