### PR TITLE
Add Canon CR-N100 basic support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1425,6 +1425,16 @@
         </select>
       </div>
       <div class="field">
+        <label for="f-camera-model">Camera Model</label>
+        <select id="f-camera-model">
+          <option value="avipas-visca">AVIPAS / Standard VISCA IP</option>
+          <option value="canon-cr-n100">Canon CR-N100 (basic)</option>
+        </select>
+        <div id="f-camera-model-note" class="field-note">
+          Uses the existing standard IP PTZ control path. Canon XC Protocol support is planned for a later phase.
+        </div>
+      </div>
+      <div class="field">
         <label for="f-atem-input">ATEM Source Number</label>
         <input id="f-atem-input" type="number" min="1" placeholder="Optional" />
         <div class="field-note">
@@ -1459,6 +1469,9 @@
           <label for="f-stream-url">Stream URL (RTMP, HLS, etc.)</label>
           <input id="f-stream-url" type="text" placeholder="https://example.com/stream.m3u8" autocomplete="off" spellcheck="false" />
           <div class="field-note" style="color: var(--muted);">Supported: standard HTTP streams, RTMP, HLS. Not supported: vdo.ninja, WebRTC.</div>
+          <div id="f-canon-capture-note" class="field-note" style="display:none;">
+            Canon CR-N100 basic support expects preset image capture through the existing USB device path or ATEM-routed USB capture. RTSP, SRT, NDI, and XC control are not part of this workflow yet.
+          </div>
         </div>
         <div id="f-capture-source-status" class="field-note">Scan capture source: Not configured</div>
       </div>
@@ -1793,13 +1806,29 @@
   'use strict';
 
   const BUILD_COMMIT = '5efe1f2';
+  const DEFAULT_CAMERA_MODEL = 'avipas-visca';
+  const CANON_CR_N100_CAMERA_MODEL = 'canon-cr-n100';
+  const CAMERA_MODEL_META = {
+    [DEFAULT_CAMERA_MODEL]: {
+      label: 'AVIPAS / Standard VISCA IP',
+      defaultPort: 1259,
+      defaultViscaAddr: 1,
+      modelNote: 'Uses the existing standard IP PTZ control path. Stream URL capture remains optional for non-Canon workflows.',
+    },
+    [CANON_CR_N100_CAMERA_MODEL]: {
+      label: 'Canon CR-N100 (basic)',
+      defaultPort: 52381,
+      defaultViscaAddr: 1,
+      modelNote: 'Basic Canon support uses standard IP PTZ control plus USB or ATEM-routed USB capture. XC Protocol support is planned for a later phase.',
+    },
+  };
 
   // ── State ──────────────────────────────────────────────────────────────────
   const DEF_CAMERAS = [
-    { name: 'Camera 1', ip: '', port: 52381, viscaAddr: 1, atemInput: 1, streamUrl: '', usbDevice: '', enabled: true },
-    { name: 'Camera 2', ip: '', port: 52381, viscaAddr: 1, atemInput: 2, streamUrl: '', usbDevice: '', enabled: true },
-    { name: 'Camera 3', ip: '', port: 52381, viscaAddr: 1, atemInput: 3, streamUrl: '', usbDevice: '', enabled: true },
-    { name: 'Camera 4', ip: '', port: 52381, viscaAddr: 1, atemInput: 4, streamUrl: '', usbDevice: '', enabled: false },
+    { name: 'Camera 1', cameraModel: DEFAULT_CAMERA_MODEL, ip: '', port: 52381, viscaAddr: 1, atemInput: 1, streamUrl: '', usbDevice: '', enabled: true },
+    { name: 'Camera 2', cameraModel: DEFAULT_CAMERA_MODEL, ip: '', port: 52381, viscaAddr: 1, atemInput: 2, streamUrl: '', usbDevice: '', enabled: true },
+    { name: 'Camera 3', cameraModel: DEFAULT_CAMERA_MODEL, ip: '', port: 52381, viscaAddr: 1, atemInput: 3, streamUrl: '', usbDevice: '', enabled: true },
+    { name: 'Camera 4', cameraModel: DEFAULT_CAMERA_MODEL, ip: '', port: 52381, viscaAddr: 1, atemInput: 4, streamUrl: '', usbDevice: '', enabled: false },
   ];
 
   const JOYSTICK_PROFILES = {
@@ -1867,6 +1896,19 @@
         ...(virtual.sensitivity || {}),
       },
     };
+  }
+
+  function normalizeCameraModel(value) {
+    return CAMERA_MODEL_META[value] ? value : DEFAULT_CAMERA_MODEL;
+  }
+
+  function getCameraModelMeta(value) {
+    return CAMERA_MODEL_META[normalizeCameraModel(value)] || CAMERA_MODEL_META[DEFAULT_CAMERA_MODEL];
+  }
+
+  function getCameraModel(camOrIdx) {
+    const cam = typeof camOrIdx === 'number' ? state.cameras[camOrIdx] : camOrIdx;
+    return normalizeCameraModel(cam && cam.cameraModel);
   }
 
   function detectGamepadMode() {
@@ -2077,10 +2119,14 @@
       if (res.ok) {
         const s = await res.json();
         if (Array.isArray(s.cameras) && s.cameras.length) {
-          state.cameras = DEF_CAMERAS.map((defaults, idx) => ({
-            ...defaults,
-            ...(s.cameras[idx] || {}),
-          }));
+          state.cameras = DEF_CAMERAS.map((defaults, idx) => {
+            const merged = {
+              ...defaults,
+              ...(s.cameras[idx] || {}),
+            };
+            merged.cameraModel = normalizeCameraModel(merged.cameraModel);
+            return merged;
+          });
         }
         if (s.activeCam != null) state.activeCam = +s.activeCam;
         if (s.labels)   state.labels  = s.labels;
@@ -2326,6 +2372,7 @@
     if (!cam) return 'Not configured';
     if (cam.usbDevice) return getUsbDeviceName(cam.usbDevice);
     if (cam.streamUrl) return 'VDO.ninja / URL';
+    if (getCameraModel(cam) === CANON_CR_N100_CAMERA_MODEL) return 'Use USB or ATEM-routed USB capture';
     if (videoStream) return 'Browser preview camera';
     return 'Not configured';
   }
@@ -2918,6 +2965,9 @@
   const elIp        = document.getElementById('f-ip');
   const elPort      = document.getElementById('f-port');
   const elVisca     = document.getElementById('f-visca');
+  const elCameraModel = document.getElementById('f-camera-model');
+  const elCameraModelNote = document.getElementById('f-camera-model-note');
+  const elCanonCaptureNote = document.getElementById('f-canon-capture-note');
   const elAtemInput = document.getElementById('f-atem-input');
   const elAtemStatus = document.getElementById('f-atem-status');
   const elCaptureSourceStatus = document.getElementById('f-capture-source-status');
@@ -2933,6 +2983,21 @@
     if (elScanWaitMode) elScanWaitMode.value = manual ? 'dwell' : 'settle';
     if (elDwell) elDwell.disabled = !manual;
     if (elScanDwellField) elScanDwellField.style.opacity = manual ? '1' : '0.6';
+  }
+
+  function updateCameraModelUi(cam = state.cameras[settingsCameraIdx]) {
+    const model = getCameraModel(cam);
+    const meta = getCameraModelMeta(model);
+    if (elCameraModel) elCameraModel.value = model;
+    if (elCameraModelNote) elCameraModelNote.textContent = meta.modelNote;
+    if (elCanonCaptureNote) {
+      elCanonCaptureNote.style.display = model === CANON_CR_N100_CAMERA_MODEL ? 'block' : 'none';
+    }
+    if (elStreamUrl) {
+      elStreamUrl.placeholder = model === CANON_CR_N100_CAMERA_MODEL
+        ? 'Not needed for Canon basic support'
+        : 'https://example.com/stream.m3u8';
+    }
   }
 
   function updateCameraStatusHints(camIdx = state.activeCam) {
@@ -2970,6 +3035,7 @@
     elIp.value        = cam.ip;
     elPort.value      = cam.port;
     elVisca.value     = cam.viscaAddr;
+    updateCameraModelUi(cam);
     const atemInput = getCameraAtemInput(cam);
     elAtemInput.value = atemInput != null ? String(atemInput) : '';
     elDwell.value     = state.dwellMs / 1000;
@@ -2999,6 +3065,7 @@
     cam.ip         = elIp.value.trim();
     cam.port       = parseInt(elPort.value, 10) || 52381;
     cam.viscaAddr  = parseInt(elVisca.value, 10) || 1;
+    cam.cameraModel = normalizeCameraModel(elCameraModel && elCameraModel.value);
     cam.atemInput  = getCameraAtemInput({ atemInput: elAtemInput.value });
     cam.usbDevice  = elUsbDevice.value;
     cam.streamUrl  = elStreamUrl.value.trim();
@@ -3007,6 +3074,7 @@
     state.atem.enabled = elAtemEnabled.checked;
     state.atem.ip      = elAtemIp.value.trim();
     state.autoCutDelayMs = Math.max(0, Math.round(((parseFloat((elAutoCutDelay && elAutoCutDelay.value) || '0') || 0) * 1000)));
+    updateCameraModelUi(cam);
     updateCameraStatusHints();
     updateScanWaitModeUi();
   }
@@ -3019,7 +3087,7 @@
     if (elCameraSelectGuard) {
       elCameraSelectGuard.style.display = protectedLiveCamera ? 'block' : 'none';
     }
-    [elIp, elPort, elVisca, elAtemInput, elUsbDevice, elStreamUrl].forEach(el => {
+    [elIp, elPort, elVisca, elCameraModel, elAtemInput, elUsbDevice, elStreamUrl].forEach(el => {
       if (el) el.disabled = protectedLiveCamera;
     });
   }
@@ -3046,6 +3114,30 @@
   [elIp, elPort, elVisca, elAtemInput, elDwell, elScanWaitMode].forEach(el =>
     el.addEventListener('change', () => { saveCameraSettings(); schedSave(); })
   );
+
+  if (elCameraModel) {
+    elCameraModel.addEventListener('change', () => {
+      const cam = state.cameras[settingsCameraIdx];
+      const prevModel = getCameraModel(cam);
+      const nextModel = normalizeCameraModel(elCameraModel.value);
+      const prevMeta = getCameraModelMeta(prevModel);
+      const nextMeta = getCameraModelMeta(nextModel);
+      const currentPort = parseInt(elPort.value, 10) || 0;
+      const currentVisca = parseInt(elVisca.value, 10) || 0;
+      cam.cameraModel = nextModel;
+      if (!currentPort || currentPort === prevMeta.defaultPort) {
+        cam.port = nextMeta.defaultPort;
+        elPort.value = String(nextMeta.defaultPort);
+      }
+      if (!currentVisca || currentVisca === prevMeta.defaultViscaAddr) {
+        cam.viscaAddr = nextMeta.defaultViscaAddr;
+        elVisca.value = String(nextMeta.defaultViscaAddr);
+      }
+      updateCameraModelUi(cam);
+      saveCameraSettings();
+      schedSave();
+    });
+  }
 
   // ── ATEM settings ──────────────────────────────────────────────────────────
   const elAtemEnabled = document.getElementById('f-atem-enabled');

--- a/public/index.html
+++ b/public/index.html
@@ -291,7 +291,8 @@
       background: rgba(239, 68, 68, 0.12);
       border: 1px solid rgba(239, 68, 68, 0.35);
       border-radius: 999px;
-      padding: 8px 14px;
+      padding: 8px 18px;
+      min-width: 88px;
       min-height: 46px;
       color: #fca5a5;
       font-size: 0.75rem;
@@ -441,6 +442,7 @@
     body.header-compact #cut-live-btn {
       padding: 6px 12px;
       min-height: 40px;
+      min-width: 80px;
     }
     body.header-compact #btn-auto-cut {
       padding: 6px 12px;
@@ -927,7 +929,7 @@
     body.fill-mode #fill-cam-strip { display: none; }
     body.fill-mode #fullscreen-btn { padding: 4px 8px; font-size: 0.92rem; }
     body.fill-mode #protect-live-btn { padding: 4px 9px; font-size: 0.68rem; min-height: 40px; }
-    body.fill-mode #cut-live-btn { min-height: 40px; }
+    body.fill-mode #cut-live-btn { min-height: 40px; min-width: 80px; padding: 4px 12px; }
     body.fill-mode #btn-auto-cut { min-height: 40px; font-size: 0.68rem; padding: 4px 9px; }
     body.fill-mode #atem-pill { padding: 4px 8px; font-size: 0.68rem; }
     body.fill-mode #status { width: 150px; max-width: 150px; flex-basis: 150px; padding: 3px 8px; font-size: 0.7rem; }
@@ -1342,8 +1344,8 @@
     <div id="cam-tabs"><!-- rendered by JS --></div>
     <div class="header-actions">
       <button id="cut-live-btn" style="display:none" title="Cut active camera to ATEM program">Cut</button>
-      <button type="button" id="protect-live-btn" title="Blocks PTZ moves, preset recalls, scans, and recaptures when the selected camera is live on ATEM program."></button>
       <button type="button" class="btn-ghost" id="btn-auto-cut" style="display:none">Auto Cut</button>
+      <button type="button" id="protect-live-btn" title="Blocks PTZ moves, preset recalls, scans, and recaptures when the selected camera is live on ATEM program."></button>
       <button type="button" id="fullscreen-btn" title="Toggle fullscreen">&#x26F6;</button>
     </div>
   </div>

--- a/server.py
+++ b/server.py
@@ -47,6 +47,20 @@ _IS_MACOS = platform.system() == "Darwin"
 
 _logger = logging.getLogger(__name__)
 VISCA_DRIVE_COMMAND_TIMEOUT_S = 0.05
+DEFAULT_CAMERA_MODEL = "avipas-visca"
+CANON_CR_N100_CAMERA_MODEL = "canon-cr-n100"
+SUPPORTED_CAMERA_MODELS = {
+    DEFAULT_CAMERA_MODEL: {
+        "label": "AVIPAS / Standard VISCA IP",
+        "defaultPort": 1259,
+        "defaultViscaAddr": 1,
+    },
+    CANON_CR_N100_CAMERA_MODEL: {
+        "label": "Canon CR-N100",
+        "defaultPort": 52381,
+        "defaultViscaAddr": 1,
+    },
+}
 
 # ── Paths ──────────────────────────────────────────────────────────────────────
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -60,6 +74,7 @@ DEFAULT_SETTINGS = {
     "cameras": [
         {
             "name": "Camera 1",
+            "cameraModel": DEFAULT_CAMERA_MODEL,
             "ip": "",
             "port": 1259,
             "viscaAddr": 1,
@@ -70,6 +85,7 @@ DEFAULT_SETTINGS = {
         },
         {
             "name": "Camera 2",
+            "cameraModel": DEFAULT_CAMERA_MODEL,
             "ip": "",
             "port": 1259,
             "viscaAddr": 2,
@@ -80,6 +96,7 @@ DEFAULT_SETTINGS = {
         },
         {
             "name": "Camera 3",
+            "cameraModel": DEFAULT_CAMERA_MODEL,
             "ip": "",
             "port": 1259,
             "viscaAddr": 3,
@@ -90,6 +107,7 @@ DEFAULT_SETTINGS = {
         },
         {
             "name": "Camera 4",
+            "cameraModel": DEFAULT_CAMERA_MODEL,
             "ip": "",
             "port": 52381,
             "viscaAddr": 1,
@@ -158,6 +176,27 @@ VISCA_POLL_INTERVAL_S = 0.2
 VISCA_STABLE_COUNT = 3
 VISCA_INQUIRY_TIMEOUT_S = 1.0
 ATEM_STATE_CONFIRM_TIMEOUT_S = 2.0
+
+
+def _normalize_camera_model(value: str | None) -> str:
+    if value in SUPPORTED_CAMERA_MODELS:
+        return value
+    return DEFAULT_CAMERA_MODEL
+
+
+def _camera_model_for_config(cfg: dict | None) -> str:
+    raw = ""
+    if isinstance(cfg, dict):
+        raw = str(cfg.get("cameraModel", "")).strip()
+    return _normalize_camera_model(raw)
+
+
+def _camera_transport_for_cfg(cfg: dict | None, port: int) -> str:
+    camera_model = _camera_model_for_config(cfg)
+    # Canon basic support uses the current standard IP control stack for v1.
+    if camera_model == CANON_CR_N100_CAMERA_MODEL:
+        return _visca_transport_for_port(port)
+    return _visca_transport_for_port(port)
 
 
 def _visca_transport_for_port(port: int) -> str:
@@ -326,6 +365,53 @@ def recall_visca_preset(
     return payload
 
 
+def recall_camera_preset(
+    ip: str,
+    port: int,
+    preset_number: int,
+    camera_address: int = 1,
+    wait_mode: str = "settle",
+    cfg: dict | None = None,
+):
+    _camera_model_for_config(cfg)
+    return recall_visca_preset(ip, port, preset_number, camera_address, wait_mode)
+
+
+def send_camera_pan_tilt_drive(
+    ip: str,
+    port: int,
+    pan_speed: int,
+    tilt_speed: int,
+    pan_dir: int,
+    tilt_dir: int,
+    camera_address: int = 1,
+    cfg: dict | None = None,
+) -> tuple[bool, str]:
+    _camera_model_for_config(cfg)
+    return send_visca_pan_tilt_drive(
+        ip,
+        port,
+        pan_speed,
+        tilt_speed,
+        pan_dir,
+        tilt_dir,
+        camera_address=camera_address,
+    )
+
+
+def send_camera_zoom_drive(
+    ip: str,
+    port: int,
+    zoom_value: float,
+    camera_address: int = 1,
+    cfg: dict | None = None,
+) -> tuple[bool, str]:
+    _camera_model_for_config(cfg)
+    return send_visca_zoom_drive(
+        ip, port, zoom_value, camera_address=camera_address
+    )
+
+
 def inquire_visca_absolute_position(
     ip: str, port: int, camera_address: int = 1
 ) -> tuple[bool, dict | str]:
@@ -360,6 +446,13 @@ def inquire_visca_absolute_position(
         return False, str(exc)
 
 
+def inquire_camera_absolute_position(
+    ip: str, port: int, camera_address: int = 1, cfg: dict | None = None
+) -> tuple[bool, dict | str]:
+    _camera_model_for_config(cfg)
+    return inquire_visca_absolute_position(ip, port, camera_address)
+
+
 # ── Settings ───────────────────────────────────────────────────────────────────
 def _ensure_dirs():
     os.makedirs(IMAGES_DIR, exist_ok=True)
@@ -388,7 +481,11 @@ def _normalize_settings(data: dict | None) -> dict:
             raw_camera = raw_cameras[idx] if idx < len(raw_cameras) else {}
             if not isinstance(raw_camera, dict):
                 raw_camera = {}
-            merged_cameras.append({**default_camera, **raw_camera})
+            merged_camera = {**default_camera, **raw_camera}
+            merged_camera["cameraModel"] = _normalize_camera_model(
+                str(merged_camera.get("cameraModel", ""))
+            )
+            merged_cameras.append(merged_camera)
         settings["cameras"] = merged_cameras
 
     raw_atem = data.get("atem")
@@ -1651,7 +1748,7 @@ def _try_record_position(settings: dict, cam: int, preset: int) -> dict | None:
         return None
     port = int(cfg.get("port", 52381) or 52381)
     visca_addr = int(cfg.get("viscaAddr", 1) or 1)
-    ok, result = inquire_visca_absolute_position(ip, port, visca_addr)
+    ok, result = inquire_camera_absolute_position(ip, port, visca_addr, cfg)
     if not ok or not isinstance(result, dict):
         print(
             f"[Position] Skip record: inquiry failed for camera {cam} (ok={ok}, result_type={type(result).__name__})"
@@ -1871,7 +1968,10 @@ class Handler(BaseHTTPRequestHandler):
                     )
                 self._json(409, {"success": False, "message": block_reason})
                 return
-        result = recall_visca_preset(ip, port, preset, camera, wait_mode)
+        if cfg is not None:
+            result = recall_camera_preset(ip, port, preset, camera, wait_mode, cfg)
+        else:
+            result = recall_camera_preset(ip, port, preset, camera, wait_mode)
         if not result.get("success"):
             _logger.warning(
                 "Recall failed ip=%s port=%s cam=%s preset=%s wait=%s: %s",
@@ -1972,7 +2072,7 @@ class Handler(BaseHTTPRequestHandler):
                 else max(1, min(0x10, int(round(tilt_mag * 0x10))))
             )
 
-            pt_ok, pt_message = send_visca_pan_tilt_drive(
+            pt_ok, pt_message = send_camera_pan_tilt_drive(
                 ip,
                 port,
                 pan_speed,
@@ -1980,9 +2080,10 @@ class Handler(BaseHTTPRequestHandler):
                 pan_dir,
                 tilt_dir,
                 camera_address=visca_addr,
+                cfg=cfg,
             )
-            zoom_ok, zoom_message = send_visca_zoom_drive(
-                ip, port, zoom, camera_address=visca_addr
+            zoom_ok, zoom_message = send_camera_zoom_drive(
+                ip, port, zoom, camera_address=visca_addr, cfg=cfg
             )
             ok = pt_ok and zoom_ok
         self._json(
@@ -2220,7 +2321,7 @@ class Handler(BaseHTTPRequestHandler):
             self._json(400, {"ok": False, "error": "Camera IP is not configured"})
             return
 
-        ok, result = inquire_visca_absolute_position(ip, port, visca_addr)
+        ok, result = inquire_camera_absolute_position(ip, port, visca_addr, cfg)
         if ok:
             self._json(200, {"ok": True, **result})
         else:

--- a/server.py
+++ b/server.py
@@ -407,9 +407,7 @@ def send_camera_zoom_drive(
     cfg: dict | None = None,
 ) -> tuple[bool, str]:
     _camera_model_for_config(cfg)
-    return send_visca_zoom_drive(
-        ip, port, zoom_value, camera_address=camera_address
-    )
+    return send_visca_zoom_drive(ip, port, zoom_value, camera_address=camera_address)
 
 
 def inquire_visca_absolute_position(

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -31,6 +31,8 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn('id="cut-live-btn"', self.html)
 
     def test_explicit_scan_and_atem_mapping_hints_present(self):
+        self.assertIn("Camera Model", self.html)
+        self.assertIn("Canon CR-N100 (basic)", self.html)
         self.assertIn("ATEM Source Number", self.html)
         self.assertIn("ATEM bus status:", self.html)
         self.assertIn("PTZ scan uses:", self.html)
@@ -50,6 +52,10 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("Scan Output", self.html)
         self.assertIn("Active Cam", self.html)
         self.assertIn("Route to:", self.html)
+        self.assertIn(
+            "Canon CR-N100 basic support expects preset image capture through the existing USB device path or ATEM-routed USB capture.",
+            self.html,
+        )
 
     def test_live_protection_and_manage_copy_are_explicit(self):
         self.assertIn(
@@ -155,6 +161,15 @@ class TestFrontendContracts(unittest.TestCase):
             "elBuildCommit.title = `${branch} @ ${shortCommit} (${dirty}, ${defaultState})`;",
             self.html,
         )
+
+    def test_camera_model_is_normalized_and_persisted(self):
+        self.assertIn("const DEFAULT_CAMERA_MODEL = 'avipas-visca';", self.html)
+        self.assertIn("const CANON_CR_N100_CAMERA_MODEL = 'canon-cr-n100';", self.html)
+        self.assertIn("function normalizeCameraModel(value)", self.html)
+        self.assertIn("cameraModel: DEFAULT_CAMERA_MODEL", self.html)
+        self.assertIn("merged.cameraModel = normalizeCameraModel(merged.cameraModel);", self.html)
+        self.assertIn("cam.cameraModel = normalizeCameraModel(elCameraModel && elCameraModel.value);", self.html)
+        self.assertIn("id=\"f-camera-model\"", self.html)
 
     def test_auto_cut_uses_trigger_to_skip_fallback_delay(self):
         self.assertIn(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -355,6 +355,7 @@ class TestDefaultSettings(unittest.TestCase):
         cam = server.DEFAULT_SETTINGS["cameras"][0]
         for key in (
             "name",
+            "cameraModel",
             "ip",
             "port",
             "viscaAddr",
@@ -862,6 +863,14 @@ class TestHTTPRoutes(unittest.TestCase):
         _, body2 = self.srv.get("/settings")
         self.assertEqual(json.loads(body2)["activeCam"], 2)
 
+    def test_get_settings_includes_camera_model_defaults(self):
+        status, body = self.srv.get("/settings")
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertEqual(
+            data["cameras"][0]["cameraModel"], server.DEFAULT_CAMERA_MODEL
+        )
+
     def test_post_settings_bad_json_returns_400(self):
         status, body = self.srv.post("/settings", b"not json")
         self.assertEqual(status, 400)
@@ -911,7 +920,7 @@ class TestHTTPRoutes(unittest.TestCase):
             {"ip": "10.0.0.1", "port": 52381, "camera": 1, "preset": 4}
         ).encode()
         with patch(
-            "server.recall_visca_preset",
+            "server.recall_camera_preset",
             return_value={
                 "success": True,
                 "message": "ACK 9041ff • Completion 9051ff • Settled pan 1234 tilt 5678 zoom 00AA",
@@ -940,7 +949,7 @@ class TestHTTPRoutes(unittest.TestCase):
         ).encode()
         with (
             patch(
-                "server.recall_visca_preset",
+                "server.recall_camera_preset",
                 return_value={
                     "success": False,
                     "message": "Motion did not settle in time",
@@ -1009,9 +1018,9 @@ class TestHTTPRoutes(unittest.TestCase):
 
         with (
             patch(
-                "server.send_visca_pan_tilt_drive", return_value=(True, "pt ok")
+                "server.send_camera_pan_tilt_drive", return_value=(True, "pt ok")
             ) as mock_pt,
-            patch("server.send_visca_zoom_drive", return_value=(True, "zoom ok")),
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok")),
         ):
             first_status, _ = self.srv.post("/api/ptz/drive", first)
             stale_status, stale_body = self.srv.post("/api/ptz/drive", stale)
@@ -1040,9 +1049,9 @@ class TestHTTPRoutes(unittest.TestCase):
 
         with (
             patch(
-                "server.send_visca_pan_tilt_drive", return_value=(True, "pt ok")
+                "server.send_camera_pan_tilt_drive", return_value=(True, "pt ok")
             ) as mock_pt,
-            patch("server.send_visca_zoom_drive", return_value=(True, "zoom ok")),
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok")),
         ):
             self.srv.post("/api/ptz/drive", first)
             status, body = self.srv.post("/api/ptz/drive", newer)
@@ -1089,7 +1098,7 @@ class TestHTTPRoutes(unittest.TestCase):
             }
         ).encode()
         with patch(
-            "server.recall_visca_preset",
+            "server.recall_camera_preset",
             return_value={
                 "success": True,
                 "message": "ACK 9041ff • Manual dwell mode",
@@ -1118,7 +1127,7 @@ class TestHTTPRoutes(unittest.TestCase):
             }
         ).encode()
         with patch(
-            "server.recall_visca_preset",
+            "server.recall_camera_preset",
             return_value={
                 "success": True,
                 "message": "Command sent",
@@ -1147,7 +1156,7 @@ class TestHTTPRoutes(unittest.TestCase):
             }
         ).encode()
         with patch(
-            "server.recall_visca_preset",
+            "server.recall_camera_preset",
             return_value={
                 "success": True,
                 "message": "VISCA completion confirmed",
@@ -1164,6 +1173,79 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertTrue(data["success"])
         self.assertEqual(data["waitMode"], "autocut")
         mock_recall.assert_called_once_with("10.0.0.1", 52381, 5, 1, "autocut")
+
+    def test_recall_uses_camera_model_dispatch_when_camera_is_configured(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(
+                server.DEFAULT_SETTINGS["cameras"][0],
+                ip="10.0.0.1",
+                port=52381,
+                viscaAddr=1,
+                cameraModel=server.CANON_CR_N100_CAMERA_MODEL,
+            )
+        ]
+        server.write_settings(settings)
+        payload = json.dumps(
+            {"ip": "10.0.0.1", "port": 52381, "camera": 1, "preset": 5}
+        ).encode()
+        with patch(
+            "server.recall_camera_preset",
+            return_value={
+                "success": True,
+                "message": "Command sent",
+                "settled": False,
+                "sawCompletion": False,
+                "waitMode": "settle",
+                "position": None,
+            },
+        ) as mock_recall:
+            status, _ = self.srv.post("/recall", payload)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(mock_recall.call_count, 1)
+        self.assertEqual(
+            mock_recall.call_args.args[:5], ("10.0.0.1", 52381, 5, 1, "settle")
+        )
+        self.assertEqual(
+            mock_recall.call_args.args[5]["cameraModel"],
+            server.CANON_CR_N100_CAMERA_MODEL,
+        )
+
+    def test_ptz_drive_uses_camera_model_dispatch(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(
+                server.DEFAULT_SETTINGS["cameras"][0],
+                ip="10.0.0.1",
+                cameraModel=server.CANON_CR_N100_CAMERA_MODEL,
+            )
+        ]
+        server.write_settings(settings)
+        payload = json.dumps(
+            {"camIdx": 0, "pan": 0.4, "tilt": 0.1, "zoom": 0.2, "commandId": 700}
+        ).encode()
+
+        with (
+            patch(
+                "server.send_camera_pan_tilt_drive", return_value=(True, "pt ok")
+            ) as mock_pt,
+            patch(
+                "server.send_camera_zoom_drive", return_value=(True, "zoom ok")
+            ) as mock_zoom,
+        ):
+            status, body = self.srv.post("/api/ptz/drive", payload)
+
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body)["ok"])
+        self.assertEqual(
+            mock_pt.call_args.kwargs["cfg"]["cameraModel"],
+            server.CANON_CR_N100_CAMERA_MODEL,
+        )
+        self.assertEqual(
+            mock_zoom.call_args.kwargs["cfg"]["cameraModel"],
+            server.CANON_CR_N100_CAMERA_MODEL,
+        )
 
     # ── image API ──────────────────────────────────────────────────────────────
 
@@ -1709,6 +1791,7 @@ class TestDefaultSettingsCamera4(unittest.TestCase):
         cam = self._cam4()
         for key in (
             "name",
+            "cameraModel",
             "ip",
             "port",
             "viscaAddr",


### PR DESCRIPTION
## Summary
- add basic Canon CR-N100 camera model support through the existing IP PTZ control path
- keep preset image capture on the existing USB and ATEM-routed USB workflows
- adjust the live header controls by swapping Auto Cut and Protect Live Camera and widening Cut

## Testing
- ruff check server.py tests/test_server.py tests/test_frontend_contracts.py
- python -m py_compile server.py
- uv run pytest tests/test_server.py
- uv run pytest tests/test_frontend_contracts.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per‑camera "Camera Model" selector in Settings with persistent selection and model-based default ports/addresses that auto-fill when chosen.
  * Canon CR‑N100 users see a Canon-specific capture guidance hint.

* **Style**
  * Adjusted header/toggle button sizing and touch targets for improved usability.

* **Tests**
  * Frontend and server tests updated to cover camera model persistence, normalization, and model-aware camera operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/119)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->