### PR TITLE
[codex] Fix webcam recapture error handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5087,6 +5087,10 @@
       body:    blob,
     });
     const webcamData = await webcamRes.json().catch(() => ({}));
+    if (!webcamRes.ok) {
+      setStatus('error', webcamData.error || 'Capture failed');
+      return false;
+    }
     if (webcamData.position) state.positions[presetKey(cam, preset)] = webcamData.position;
     return true;
   }

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -86,6 +86,14 @@ class TestFrontendContracts(unittest.TestCase):
             "if (webcamData.position) state.positions[presetKey(cam, preset)] = webcamData.position;",
             self.html,
         )
+        self.assertIn(
+            "if (!webcamRes.ok) {",
+            self.html,
+        )
+        self.assertIn(
+            "setStatus('error', webcamData.error || 'Capture failed');",
+            self.html,
+        )
         # position cleared on image delete
         self.assertIn("delete state.positions[presetKey(cam, preset)];", self.html)
         # position shown as tooltip on preset button


### PR DESCRIPTION
## Summary
- make browser-webcam recapture honor  failures instead of silently reporting success
- surface the backend error message in the status pill when the fallback upload is rejected
- add a frontend contract assertion for the new error handling path

## Root cause
The browser-webcam fallback path did not check , so recapture could appear to succeed even when the server rejected the image upload.

## Validation
- All checks passed!
- 
- ============================= test session starts ==============================
platform darwin -- Python 3.12.6, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/ctennant/.codex/worktrees/f3ac/Ptz
plugins: flask-1.3.0, anyio-4.13.0
collected 24 items

tests/test_frontend_contracts.py ........................                [100%]

============================== 24 passed in 0.03s ==============================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced webcam capture error handling. When a capture request fails, the UI now displays an error message instead of attempting to process invalid data, providing clearer feedback.

## Tests
* Added test coverage for webcam capture failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/witeshadow/Ptz/pull/120)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->