### PR TITLE
[codex] Add server joystick controls

### DIFF
--- a/GAMEPAD_SETUP.md
+++ b/GAMEPAD_SETUP.md
@@ -72,6 +72,37 @@ Once in DirectInput mode:
 3. **Sensitivity**: Adjust as needed (start with 1.0x for pan/tilt)
 4. The debug panel should show a suggestion if mode is wrong
 
+### Browser vs Server Driver
+
+By default, physical joystick control uses the browser Gamepad API. That means the browser must stay open for joystick input.
+
+To run the joystick from `python server.py` instead:
+
+1. Install the optional dependency:
+
+```bash
+pip install pygame hidapi
+```
+
+2. In Settings → Joystick Control:
+   - Check **Enable Physical Joystick**
+   - Check **Run Physical Joystick in Python Server**
+   - Select the correct device profile
+
+When the server driver is enabled, the browser-side joystick driver is turned off so both drivers do not send PTZ commands at the same time. The server still honors Protect Live Camera and blocks movement when the target camera is live on ATEM program.
+
+The server tries `pygame` first, then falls back to direct HID for the Logitech Extreme 3D Pro if SDL does not expose it.
+
+### Logitech Extreme 3D Pro Server Controls
+
+With the Python server driver enabled, the Logitech profile also supports:
+
+- Trigger: stop pan, tilt, and zoom immediately
+- Thumb button: toggle fine-control mode
+- Hat switch: nudge pan/tilt at a fixed low speed
+
+Each of those mappings can be disabled in Settings -> Joystick Control.
+
 ## Understanding Debug Output
 
 When enabled, you'll see:

--- a/public/index.html
+++ b/public/index.html
@@ -1680,6 +1680,24 @@
         <input id="f-joystick-enabled" type="checkbox" />
         <span>Enable Physical Joystick</span>
       </label>
+      <label class="atem-toggle-wrap">
+        <input id="f-joystick-server-enabled" type="checkbox" />
+        <span>Run Physical Joystick in Python Server</span>
+      </label>
+      <div style="margin:8px 0 12px 22px; display:grid; gap:6px;">
+        <label class="atem-toggle-wrap">
+          <input id="f-joystick-trigger-stop" type="checkbox" />
+          <span>Trigger stops PTZ movement</span>
+        </label>
+        <label class="atem-toggle-wrap">
+          <input id="f-joystick-thumb-fine" type="checkbox" />
+          <span>Thumb button toggles fine control</span>
+        </label>
+        <label class="atem-toggle-wrap">
+          <input id="f-joystick-hat-nudge" type="checkbox" />
+          <span>Hat switch nudges pan/tilt</span>
+        </label>
+      </div>
       <div class="field">
         <label for="f-joystick-model">Device Profile</label>
         <select id="f-joystick-model">
@@ -1716,7 +1734,8 @@
         </select>
       </div>
       <div id="joystick-status" style="color:var(--muted); font-size:0.85rem; margin-top:12px;">
-        Status: <span id="joystick-status-text">Not connected</span>
+        Browser: <span id="joystick-status-text">Not connected</span><br/>
+        Server: <span id="joystick-server-status-text">Disabled</span>
       </div>
       <div style="margin-top:12px; padding:8px; background:var(--surf2); border-radius:4px; font-size:0.8rem; line-height:1.5;">
         <strong>Gamepad Setup:</strong><br/>
@@ -1855,6 +1874,8 @@
       sensitivity: { pan: 1.0, tilt: 1.0, zoom: 0.5 },
       axisMap: { pan: 0, tilt: 1, zoom: 2 },
       buttonMap: { preset1: 0, preset2: 1, preset3: 2, preset4: 3 },
+      serverButtonMap: { triggerStop: 0, toggleFine: 1 },
+      serverActions: { triggerStop: true, thumbFine: true, hatNudge: true },
       useDpad: false,
     },
     '8bitdo-zero2': {
@@ -1863,6 +1884,8 @@
       sensitivity: { pan: 1.0, tilt: 1.0, zoom: 0.5 },
       axisMap: { zoom: 2 },
       buttonMap: { preset1: 4, preset2: 5, preset3: 6, preset4: 7 },
+      serverButtonMap: { triggerStop: 0, toggleFine: 1 },
+      serverActions: { triggerStop: true, thumbFine: true, hatNudge: true },
       useDpad: true,
       dpadMap: { up: 12, down: 13, left: 14, right: 15 },
     },
@@ -1879,11 +1902,16 @@
 
     const defaults = {
       enabled: false,
+      serverEnabled: false,
       model: model,
       deadzone: profile.deadzone,
       sensitivity: { ...profile.sensitivity },
       axisMap: { ...profile.axisMap },
       buttonMap: { ...profile.buttonMap },
+      serverButtonMap: { ...(profile.serverButtonMap || {}) },
+      serverActions: { ...(profile.serverActions || {}) },
+      dpadMap: { ...(profile.dpadMap || {}) },
+      useDpad: !!profile.useDpad,
       zoomCompensationCurve: "linear",
     };
 
@@ -1893,6 +1921,9 @@
       sensitivity: { ...defaults.sensitivity, ...(joystick.sensitivity || {}) },
       axisMap: { ...defaults.axisMap, ...(joystick.axisMap || {}) },
       buttonMap: { ...defaults.buttonMap, ...(joystick.buttonMap || {}) },
+      serverButtonMap: { ...defaults.serverButtonMap, ...(joystick.serverButtonMap || {}) },
+      serverActions: { ...defaults.serverActions, ...(joystick.serverActions || {}) },
+      dpadMap: { ...defaults.dpadMap, ...(joystick.dpadMap || {}) },
     };
   }
 
@@ -1929,8 +1960,7 @@
   }
 
   function detectGamepadMode() {
-    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
-    const gamepad = [...gamepads].find(Boolean);
+    const gamepad = getConnectedGamepad();
     if (!gamepad) return null;
 
     const id = gamepad.id.toLowerCase();
@@ -1974,6 +2004,7 @@
     atem: { ip: '', enabled: false },
     showAtemDebug: false,
     showJoystickDebug: false,
+    serverJoystickStatus: null,
     protectLiveCamera: true,
     atemFollows: 'preview',
     autoCutDelayMs: 0,
@@ -2606,8 +2637,7 @@
       return;
     }
     elJoystickDebug.style.display = 'block';
-    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
-    const gamepad = [...gamepads].find(Boolean);
+    const gamepad = getConnectedGamepad();
     if (gamepad) {
       const cfg = state.joystick || {};
       const axisMap = cfg.axisMap || { pan: 0, tilt: 1, zoom: 2 };
@@ -2929,7 +2959,7 @@
     state.activeCam = idx;
     state.managedPresetId = null;
     currentCameraZoom = { value: 0, timestamp: 0 };
-    if (gamepadConnected && state.joystick?.enabled) {
+    if (gamepadConnected && browserJoystickEnabled()) {
       startZoomPolling();
     }
     closePresetManageSheet();
@@ -3845,10 +3875,10 @@
   }
 
   function updateGamepadState() {
-    if (!state.joystick || !state.joystick.enabled) return;
+    gamepadAnimationFrame = null;
+    if (!browserJoystickEnabled()) return;
 
-    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
-    const gamepad = [...gamepads].find(Boolean);
+    const gamepad = getConnectedGamepad();
     if (!gamepad) {
       if (gamepadConnected) {
         gamepadConnected = false;
@@ -3858,6 +3888,8 @@
         console.debug('[PTZ] Gamepad disconnected');
         updateJoystickStatus();
       }
+      updateJoystickDebug();
+      scheduleGamepadPolling();
       return;
     }
 
@@ -3866,7 +3898,7 @@
       console.debug('[PTZ] Gamepad connected:', gamepad.id);
       updateJoystickStatus();
     }
-    if (!zoomPollTimer && state.joystick?.enabled) {
+    if (!zoomPollTimer && browserJoystickEnabled()) {
       startZoomPolling();
     }
 
@@ -3900,10 +3932,7 @@
     applyGamepadInput();
     updateJoystickDebug();
 
-    if (gamepadAnimationFrame) {
-      cancelAnimationFrame(gamepadAnimationFrame);
-    }
-    gamepadAnimationFrame = requestAnimationFrame(updateGamepadState);
+    scheduleGamepadPolling();
   }
 
   function handleGamepadButton(buttonIndex) {
@@ -3971,9 +4000,9 @@
   window.addEventListener('gamepadconnected', (e) => {
     gamepadConnected = true;
     console.debug('[PTZ] Gamepad connected:', e.gamepad.id);
-    if (state.joystick && state.joystick.enabled) {
+    if (browserJoystickEnabled()) {
       startZoomPolling();
-      updateGamepadState();
+      scheduleGamepadPolling();
     }
     updateJoystickStatus();
     updateJoystickDebug();
@@ -4080,6 +4109,27 @@
   let zoomPollSession = 0;
   let zoomPollInFlight = false;
   const ZOOM_POLL_INTERVAL_MS = 500;
+
+  function browserJoystickEnabled() {
+    return !!state.joystick?.enabled && !state.joystick?.serverEnabled;
+  }
+
+  function getConnectedGamepad() {
+    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+    return [...gamepads].find(Boolean) || null;
+  }
+
+  function scheduleGamepadPolling() {
+    if (!browserJoystickEnabled() || gamepadAnimationFrame) return;
+    gamepadAnimationFrame = requestAnimationFrame(updateGamepadState);
+  }
+
+  function stopGamepadPolling() {
+    if (gamepadAnimationFrame) {
+      cancelAnimationFrame(gamepadAnimationFrame);
+      gamepadAnimationFrame = null;
+    }
+  }
 
   function updateDpadInput(gamepad, cfg) {
     if (!cfg.useDpad) {
@@ -4454,6 +4504,10 @@
   const elVirtualJoystickEnabledCheckbox = document.getElementById('f-virtual-joystick-enabled');
   const elVirtualJoystickSize = document.getElementById('f-virtual-joystick-size');
   const elJoystickEnabled = document.getElementById('f-joystick-enabled');
+  const elJoystickServerEnabled = document.getElementById('f-joystick-server-enabled');
+  const elJoystickTriggerStop = document.getElementById('f-joystick-trigger-stop');
+  const elJoystickThumbFine = document.getElementById('f-joystick-thumb-fine');
+  const elJoystickHatNudge = document.getElementById('f-joystick-hat-nudge');
   const elJoystickModel = document.getElementById('f-joystick-model');
   const elJoystickDeadzone = document.getElementById('f-joystick-deadzone');
   const elJoystickPanSens = document.getElementById('f-joystick-pan-sens');
@@ -4461,6 +4515,7 @@
   const elJoystickZoomSens = document.getElementById('f-joystick-zoom-sens');
   const elJoystickZoomComp = document.getElementById('f-joystick-zoom-comp');
   const elJoystickStatus = document.getElementById('joystick-status-text');
+  const elJoystickServerStatus = document.getElementById('joystick-server-status-text');
   const elJoystickDebug = document.getElementById('joystick-debug');
   const elJoystickDebugCheckbox = document.getElementById('f-joystick-debug');
   const elDbgJoystickPan = document.getElementById('dbg-joystick-pan');
@@ -4580,6 +4635,10 @@
     if (elVirtualJoystickEnabledCheckbox) elVirtualJoystickEnabledCheckbox.checked = state.virtualJoystick?.enabled !== false;
     if (elVirtualJoystickSize) elVirtualJoystickSize.value = state.virtualJoystick?.size || 'normal';
     if (elJoystickEnabled) elJoystickEnabled.checked = !!js.enabled;
+    if (elJoystickServerEnabled) elJoystickServerEnabled.checked = !!js.serverEnabled;
+    if (elJoystickTriggerStop) elJoystickTriggerStop.checked = js.serverActions?.triggerStop !== false;
+    if (elJoystickThumbFine) elJoystickThumbFine.checked = js.serverActions?.thumbFine !== false;
+    if (elJoystickHatNudge) elJoystickHatNudge.checked = js.serverActions?.hatNudge !== false;
     if (elJoystickModel) elJoystickModel.value = js.model || 'logitech-extreme-3d';
     if (elJoystickDeadzone) {
       elJoystickDeadzone.value = (js.deadzone || 0.2).toFixed(2);
@@ -4602,15 +4661,30 @@
     }
     updateVirtualJoystickVisibility();
     updateJoystickStatus();
+    scheduleGamepadPolling();
   }
 
   function saveJoystickSettings() {
     const prev = normalizeJoystickSettings(state.joystick);
     const wasEnabled = !!prev.enabled;
+    const selectedModel = elJoystickModel?.value || 'logitech-extreme-3d';
+    const selectedProfile = JOYSTICK_PROFILES[selectedModel] || JOYSTICK_PROFILES['logitech-extreme-3d'];
     state.joystick = normalizeJoystickSettings({
       ...prev,
       enabled: elJoystickEnabled?.checked || false,
-      model: elJoystickModel?.value || 'logitech-extreme-3d',
+      serverEnabled: elJoystickServerEnabled?.checked || false,
+      model: selectedModel,
+      axisMap: { ...(selectedProfile.axisMap || {}) },
+      buttonMap: { ...(selectedProfile.buttonMap || {}) },
+      serverButtonMap: { ...(selectedProfile.serverButtonMap || prev.serverButtonMap || {}) },
+      serverActions: {
+        ...(selectedProfile.serverActions || prev.serverActions || {}),
+        triggerStop: elJoystickTriggerStop?.checked !== false,
+        thumbFine: elJoystickThumbFine?.checked !== false,
+        hatNudge: elJoystickHatNudge?.checked !== false,
+      },
+      dpadMap: { ...(selectedProfile.dpadMap || {}) },
+      useDpad: !!selectedProfile.useDpad,
       deadzone: parseFloat(elJoystickDeadzone?.value || 0.2),
       sensitivity: {
         ...prev.sensitivity,
@@ -4629,43 +4703,68 @@
       sensitivity: { pan: 0.6, tilt: 0.6, zoom: 0.3 },
     });
 
-    if (wasEnabled && !state.joystick.enabled) {
-      if (gamepadAnimationFrame) {
-        cancelAnimationFrame(gamepadAnimationFrame);
-        gamepadAnimationFrame = null;
-      }
+    if (wasEnabled && (!state.joystick.enabled || state.joystick.serverEnabled)) {
+      stopGamepadPolling();
       gamepadState = { pan: 0, tilt: 0, zoom: 0 };
       stopZoomPolling();
       stopPtzInput('gamepad');
-    } else if (!wasEnabled && state.joystick.enabled) {
-      const connectedGamepads = typeof navigator !== 'undefined' && navigator.getGamepads
-        ? Array.from(navigator.getGamepads()).filter(Boolean)
-        : [];
-      if (connectedGamepads.length > 0) {
+    } else if (!wasEnabled && browserJoystickEnabled()) {
+      const connectedGamepad = getConnectedGamepad();
+      if (connectedGamepad) {
         gamepadConnected = true;
         startZoomPolling();
-        if (!gamepadAnimationFrame) {
-          updateGamepadState();
-        }
       }
+      scheduleGamepadPolling();
+    } else if (browserJoystickEnabled()) {
+      scheduleGamepadPolling();
     }
 
     schedSave();
     updateVirtualJoystickVisibility();
     updateJoystickStatus();
+    void refreshServerJoystickStatus();
   }
 
   function updateJoystickStatus() {
     if (!elJoystickStatus) return;
     if (!state.joystick || !state.joystick.enabled) {
       elJoystickStatus.textContent = 'Disabled';
+      if (elJoystickServerStatus) elJoystickServerStatus.textContent = 'Disabled';
       return;
     }
-    if (gamepadConnected) {
+    if (state.joystick.serverEnabled) {
+      elJoystickStatus.textContent = 'Off; Python server driver is active';
+    } else if (gamepadConnected) {
       elJoystickStatus.textContent = 'Connected ✓';
     } else {
-      elJoystickStatus.textContent = 'Enabled, waiting for gamepad…';
+      elJoystickStatus.textContent = 'Enabled, press a joystick button or move the stick…';
     }
+    if (elJoystickServerStatus) {
+      if (!state.joystick.serverEnabled) {
+        elJoystickServerStatus.textContent = 'Disabled';
+      } else if (state.serverJoystickStatus) {
+        const s = state.serverJoystickStatus;
+        const camLabel = Number.isInteger(s.camIdx) ? ` CAM ${s.camIdx + 1}` : '';
+        const fineLabel = s.fineControl ? ' fine' : '';
+        const deviceLabel = (s.device ? `${s.device}${camLabel}${fineLabel}` : `${camLabel}${fineLabel}`).trim();
+        elJoystickServerStatus.textContent = deviceLabel
+          ? `${s.message || 'Enabled'} (${deviceLabel})`
+          : (s.message || 'Enabled');
+      } else {
+        elJoystickServerStatus.textContent = 'Starting...';
+      }
+    }
+  }
+
+  async function refreshServerJoystickStatus() {
+    if (!state.joystick?.serverEnabled) return;
+    try {
+      const res = await fetch('/api/joystick/status');
+      if (res.ok) {
+        state.serverJoystickStatus = await res.json();
+        updateJoystickStatus();
+      }
+    } catch (_) {}
   }
 
   if (elVirtualJoystickEnabledCheckbox) {
@@ -4677,7 +4776,19 @@
   }
 
   if (elJoystickEnabled) {
-    [elJoystickEnabled, elJoystickModel, elJoystickDeadzone, elJoystickPanSens, elJoystickTiltSens, elJoystickZoomSens, elJoystickZoomComp].forEach(el => {
+    [
+      elJoystickEnabled,
+      elJoystickServerEnabled,
+      elJoystickTriggerStop,
+      elJoystickThumbFine,
+      elJoystickHatNudge,
+      elJoystickModel,
+      elJoystickDeadzone,
+      elJoystickPanSens,
+      elJoystickTiltSens,
+      elJoystickZoomSens,
+      elJoystickZoomComp,
+    ].forEach(el => {
       if (el) {
         el.addEventListener('change', saveJoystickSettings);
         el.addEventListener('input', () => {
@@ -6034,6 +6145,8 @@
     loadCameraSettings();
     loadGridSettings();
     loadJoystickSettings();
+    void refreshServerJoystickStatus();
+    setInterval(refreshServerJoystickStatus, 1500);
     loadCameraManagement();
     updateToolbarVisibility();
     renderTabs();

--- a/server.py
+++ b/server.py
@@ -1980,9 +1980,7 @@ def _execute_ptz_drive(
             1 if pan_dir == 0x03 else max(1, min(0x10, int(round(pan_mag * 0x10))))
         )
         tilt_speed = (
-            1
-            if tilt_dir == 0x03
-            else max(1, min(0x10, int(round(tilt_mag * 0x10))))
+            1 if tilt_dir == 0x03 else max(1, min(0x10, int(round(tilt_mag * 0x10))))
         )
 
         previous_pan, previous_tilt, previous_zoom = _get_last_ptz_drive_command(
@@ -1999,9 +1997,7 @@ def _execute_ptz_drive(
             pt_results = []
             max_attempts = (
                 PTZ_STOP_MAX_ATTEMPTS
-                if pan == 0
-                and tilt == 0
-                and (previous_pan != 0 or previous_tilt != 0)
+                if pan == 0 and tilt == 0 and (previous_pan != 0 or previous_tilt != 0)
                 else 1
             )
             for attempt in range(max_attempts):
@@ -2128,7 +2124,9 @@ def _normalize_server_joystick_config(settings: dict) -> dict:
         "enabled": bool(raw.get("enabled")),
         "serverEnabled": bool(raw.get("serverEnabled")),
         "model": model,
-        "deadzone": float(raw.get("deadzone") or DEFAULT_SETTINGS["joystick"]["deadzone"]),
+        "deadzone": float(
+            raw.get("deadzone") or DEFAULT_SETTINGS["joystick"]["deadzone"]
+        ),
         "sensitivity": sensitivity,
         "axisMap": axis_map,
         "buttonMap": button_map,
@@ -2211,8 +2209,7 @@ def _apply_joystick_fine_control(
     if not enabled:
         return command
     return tuple(
-        _quantize_joystick_axis(axis * JOYSTICK_FINE_CONTROL_SCALE)
-        for axis in command
+        _quantize_joystick_axis(axis * JOYSTICK_FINE_CONTROL_SCALE) for axis in command
     )
 
 
@@ -2278,7 +2275,9 @@ def _server_joystick_target_cam(settings: dict) -> int:
         if follows in {"preview", "program"}:
             atem = _get_atem()
             if atem.get("connected"):
-                followed_cam = _camera_index_for_atem_source(settings, atem.get(follows))
+                followed_cam = _camera_index_for_atem_source(
+                    settings, atem.get(follows)
+                )
                 if followed_cam is not None:
                     return followed_cam
     return active_cam
@@ -2573,9 +2572,7 @@ def _joystick_loop():
                         axis_centers["zoom"],
                         [round(sample, 3) for sample in zoom_center_samples],
                     )
-                    command = _read_server_joystick_command(
-                        joystick, cfg, axis_centers
-                    )
+                    command = _read_server_joystick_command(joystick, cfg, axis_centers)
 
             sensitivity = cfg.get("sensitivity") or {}
             zoom, zoom_axis_active = _apply_zoom_start_hysteresis(

--- a/server.py
+++ b/server.py
@@ -47,6 +47,11 @@ _IS_MACOS = platform.system() == "Darwin"
 
 _logger = logging.getLogger(__name__)
 VISCA_DRIVE_COMMAND_TIMEOUT_S = 0.05
+PTZ_STOP_MAX_ATTEMPTS = 3
+PTZ_STOP_RESEND_INTERVAL_S = 0.06
+JOYSTICK_ZOOM_START_MARGIN = 0.10
+JOYSTICK_FINE_CONTROL_SCALE = 0.35
+JOYSTICK_HAT_NUDGE_SPEED = 0.35
 DEFAULT_CAMERA_MODEL = "avipas-visca"
 CANON_CR_N100_CAMERA_MODEL = "canon-cr-n100"
 SUPPORTED_CAMERA_MODELS = {
@@ -137,6 +142,7 @@ DEFAULT_SETTINGS = {
     "positions": {},
     "joystick": {
         "enabled": False,
+        "serverEnabled": False,
         "model": "logitech-extreme-3d",
         "deadzone": 0.25,
         "sensitivity": {
@@ -154,6 +160,15 @@ DEFAULT_SETTINGS = {
             "preset2": 1,
             "preset3": 2,
             "preset4": 3,
+        },
+        "serverButtonMap": {
+            "triggerStop": 0,
+            "toggleFine": 1,
+        },
+        "serverActions": {
+            "triggerStop": True,
+            "thumbFine": True,
+            "hatNudge": True,
         },
         "zoomCompensationCurve": "linear",
     },
@@ -507,6 +522,14 @@ def _normalize_settings(data: dict | None) -> dict:
                 **DEFAULT_SETTINGS["joystick"]["buttonMap"],
                 **(raw_joystick.get("buttonMap") or {}),
             },
+            "serverButtonMap": {
+                **DEFAULT_SETTINGS["joystick"]["serverButtonMap"],
+                **(raw_joystick.get("serverButtonMap") or {}),
+            },
+            "serverActions": {
+                **DEFAULT_SETTINGS["joystick"]["serverActions"],
+                **(raw_joystick.get("serverActions") or {}),
+            },
         }
 
     raw_virtual = data.get("virtualJoystick")
@@ -600,6 +623,43 @@ _atem_conn_lock = threading.Lock()
 _ptz_runtime_lock = threading.Lock()
 _ptz_last_command_ids: dict[int, int] = {}
 _ptz_camera_locks: dict[int, threading.Lock] = {}
+_ptz_last_drive_commands: dict[int, tuple[float, float, float]] = {}
+_joystick_status_lock = threading.Lock()
+_joystick_status = {
+    "enabled": False,
+    "serverEnabled": False,
+    "available": False,
+    "connected": False,
+    "device": "",
+    "message": "Server joystick driver is disabled",
+    "camIdx": None,
+    "pan": 0.0,
+    "tilt": 0.0,
+    "zoom": 0.0,
+    "fineControl": False,
+    "lastCommand": None,
+    "lastError": "",
+    "updatedAt": 0.0,
+}
+
+_JOYSTICK_PROFILES = {
+    "logitech-extreme-3d": {
+        "axisMap": {"pan": 0, "tilt": 1, "zoom": 2},
+        "buttonMap": {"preset1": 0, "preset2": 1, "preset3": 2, "preset4": 3},
+        "serverButtonMap": {"triggerStop": 0, "toggleFine": 1},
+        "serverActions": {"triggerStop": True, "thumbFine": True, "hatNudge": True},
+        "useDpad": False,
+    },
+    "8bitdo-zero2": {
+        "axisMap": {"zoom": 2},
+        "buttonMap": {"preset1": 4, "preset2": 5, "preset3": 6, "preset4": 7},
+        "useDpad": True,
+        "dpadMap": {"up": 12, "down": 13, "left": 14, "right": 15},
+    },
+}
+JOYSTICK_POLL_INTERVAL_S = 0.05
+JOYSTICK_COMMAND_INTERVAL_S = 0.08
+JOYSTICK_ERROR_RETRY_INTERVAL_S = 1.0
 
 
 def _set_atem(
@@ -629,6 +689,7 @@ def _reset_ptz_runtime_state():
     with _ptz_runtime_lock:
         _ptz_last_command_ids.clear()
         _ptz_camera_locks.clear()
+        _ptz_last_drive_commands.clear()
 
 
 def _get_ptz_camera_lock(cam_idx: int) -> threading.Lock:
@@ -651,6 +712,39 @@ def _claim_ptz_command_id(
             return False, last_seen
         _ptz_last_command_ids[cam_idx] = command_id
         return True, last_seen
+
+
+def _get_last_ptz_drive_command(cam_idx: int) -> tuple[float, float, float]:
+    with _ptz_runtime_lock:
+        return _ptz_last_drive_commands.get(cam_idx, (0.0, 0.0, 0.0))
+
+
+def _set_last_ptz_drive_command(
+    cam_idx: int, command: tuple[float, float, float]
+) -> None:
+    with _ptz_runtime_lock:
+        _ptz_last_drive_commands[cam_idx] = command
+
+
+def _combine_command_results(results: list[tuple[bool, str]]) -> tuple[bool, str]:
+    ok = all(result[0] for result in results)
+    message = "; ".join(result[1] for result in results)
+    return ok, message
+
+
+def _visca_message_has_reply(message: str) -> bool:
+    return "no VISCA response received" not in message
+
+
+def _set_joystick_status(**updates):
+    updates["updatedAt"] = time.time()
+    with _joystick_status_lock:
+        _joystick_status.update(updates)
+
+
+def _get_joystick_status() -> dict:
+    with _joystick_status_lock:
+        return dict(_joystick_status)
 
 
 def _set_atem_last_action(
@@ -1833,6 +1927,817 @@ def _require_camera(
     return True, None, cams[cam_idx]
 
 
+def _execute_ptz_drive(
+    cam_idx: int,
+    pan: float,
+    tilt: float,
+    zoom: float,
+    command_id: int | None = None,
+) -> tuple[int, dict]:
+    settings = load_settings()
+    cameras = settings.get("cameras") or []
+    if cam_idx < 0 or cam_idx >= len(cameras):
+        return 404, {"ok": False, "error": "Camera not found"}
+
+    cfg = cameras[cam_idx] or {}
+    ip = str(cfg.get("ip", "")).strip()
+    if not ip:
+        return 400, {"ok": False, "error": "Camera IP is required"}
+
+    is_stop = pan == 0 and tilt == 0 and zoom == 0
+    if not is_stop:
+        block_reason = _live_movement_block_reason(settings, cam_idx, cfg)
+        if block_reason:
+            if block_reason == "Protected live camera is on ATEM program.":
+                block_reason = (
+                    "Protected live camera is on ATEM program. Switch cameras "
+                    "or turn off Protect Live Camera before moving."
+                )
+            return 409, {"ok": False, "error": block_reason}
+
+    with _get_ptz_camera_lock(cam_idx):
+        fresh, last_seen = _claim_ptz_command_id(cam_idx, command_id)
+        if not fresh:
+            return 200, {
+                "ok": True,
+                "stale": True,
+                "commandId": command_id,
+                "lastCommandId": last_seen,
+                "camIdx": cam_idx,
+                "pan": pan,
+                "tilt": tilt,
+                "zoom": zoom,
+            }
+
+        port = int(cfg.get("port", 52381) or 52381)
+        visca_addr = int(cfg.get("viscaAddr", 1) or 1)
+        deadzone = 0.20
+        pan_mag = abs(pan)
+        tilt_mag = abs(tilt)
+        pan_dir = 0x03 if pan_mag < deadzone else (0x01 if pan < 0 else 0x02)
+        tilt_dir = 0x03 if tilt_mag < deadzone else (0x01 if tilt > 0 else 0x02)
+        pan_speed = (
+            1 if pan_dir == 0x03 else max(1, min(0x10, int(round(pan_mag * 0x10))))
+        )
+        tilt_speed = (
+            1
+            if tilt_dir == 0x03
+            else max(1, min(0x10, int(round(tilt_mag * 0x10))))
+        )
+
+        previous_pan, previous_tilt, previous_zoom = _get_last_ptz_drive_command(
+            cam_idx
+        )
+        pan_tilt_changed = pan != previous_pan or tilt != previous_tilt
+        zoom_changed = zoom != previous_zoom
+
+        pt_ok = True
+        zoom_ok = True
+        pt_message = "Pan/tilt unchanged"
+        zoom_message = "Zoom unchanged"
+        if pan_tilt_changed:
+            pt_results = []
+            max_attempts = (
+                PTZ_STOP_MAX_ATTEMPTS
+                if pan == 0
+                and tilt == 0
+                and (previous_pan != 0 or previous_tilt != 0)
+                else 1
+            )
+            for attempt in range(max_attempts):
+                if attempt:
+                    time.sleep(PTZ_STOP_RESEND_INTERVAL_S)
+                result = send_camera_pan_tilt_drive(
+                    ip,
+                    port,
+                    pan_speed,
+                    tilt_speed,
+                    pan_dir,
+                    tilt_dir,
+                    camera_address=visca_addr,
+                    cfg=cfg,
+                )
+                pt_results.append(result)
+                if result[0] and _visca_message_has_reply(result[1]):
+                    break
+            pt_ok, pt_message = _combine_command_results(pt_results)
+        if zoom_changed:
+            zoom_results = []
+            max_attempts = (
+                PTZ_STOP_MAX_ATTEMPTS if zoom == 0 and previous_zoom != 0 else 1
+            )
+            for attempt in range(max_attempts):
+                if attempt:
+                    time.sleep(PTZ_STOP_RESEND_INTERVAL_S)
+                result = send_camera_zoom_drive(
+                    ip, port, zoom, camera_address=visca_addr, cfg=cfg
+                )
+                zoom_results.append(result)
+                if result[0] and _visca_message_has_reply(result[1]):
+                    break
+            zoom_ok, zoom_message = _combine_command_results(zoom_results)
+        ok = pt_ok and zoom_ok
+        if ok:
+            _set_last_ptz_drive_command(cam_idx, (pan, tilt, zoom))
+
+    return 200 if ok else 502, {
+        "ok": ok,
+        "stale": False,
+        "commandId": command_id,
+        "camIdx": cam_idx,
+        "pan": pan,
+        "tilt": tilt,
+        "zoom": zoom,
+        "panTiltMessage": pt_message,
+        "zoomMessage": zoom_message,
+    }
+
+
+def _clamp_axis(value: float) -> float:
+    return max(-1.0, min(1.0, float(value or 0.0)))
+
+
+def _apply_joystick_deadzone(value: float, deadzone: float) -> float:
+    value = _clamp_axis(value)
+    return 0.0 if abs(value) < deadzone else value
+
+
+def _apply_zoom_start_hysteresis(
+    zoom: float, deadzone: float, sensitivity: float, active: bool
+) -> tuple[float, bool]:
+    zoom = _clamp_axis(zoom)
+    if zoom == 0:
+        return 0.0, False
+    if active:
+        return zoom, True
+    start_threshold = min(1.0, deadzone + JOYSTICK_ZOOM_START_MARGIN) * abs(
+        sensitivity or 1.0
+    )
+    if abs(zoom) < start_threshold:
+        return 0.0, False
+    return zoom, True
+
+
+def _quantize_joystick_axis(value: float) -> float:
+    return round(_clamp_axis(value) / 0.05) * 0.05
+
+
+def _normalize_hid_axis(value: int, center: int, low: int, high: int) -> float:
+    if value == center:
+        return 0.0
+    if value > center:
+        span = max(1, high - center)
+    else:
+        span = max(1, center - low)
+    return _clamp_axis((value - center) / span)
+
+
+def _normalize_server_joystick_config(settings: dict) -> dict:
+    raw = settings.get("joystick") if isinstance(settings.get("joystick"), dict) else {}
+    model = str(raw.get("model") or "logitech-extreme-3d")
+    profile = _JOYSTICK_PROFILES.get(model) or _JOYSTICK_PROFILES["logitech-extreme-3d"]
+    sensitivity = {
+        **DEFAULT_SETTINGS["joystick"]["sensitivity"],
+        **profile.get("sensitivity", {}),
+        **(raw.get("sensitivity") or {}),
+    }
+    axis_map = {
+        **profile.get("axisMap", {}),
+        **(raw.get("axisMap") or {}),
+    }
+    button_map = {
+        **profile.get("buttonMap", {}),
+        **(raw.get("buttonMap") or {}),
+    }
+    server_button_map = {
+        **DEFAULT_SETTINGS["joystick"]["serverButtonMap"],
+        **profile.get("serverButtonMap", {}),
+        **(raw.get("serverButtonMap") or {}),
+    }
+    server_actions = {
+        **DEFAULT_SETTINGS["joystick"]["serverActions"],
+        **profile.get("serverActions", {}),
+        **(raw.get("serverActions") or {}),
+    }
+    dpad_map = {
+        **profile.get("dpadMap", {}),
+        **(raw.get("dpadMap") or {}),
+    }
+    return {
+        **raw,
+        "enabled": bool(raw.get("enabled")),
+        "serverEnabled": bool(raw.get("serverEnabled")),
+        "model": model,
+        "deadzone": float(raw.get("deadzone") or DEFAULT_SETTINGS["joystick"]["deadzone"]),
+        "sensitivity": sensitivity,
+        "axisMap": axis_map,
+        "buttonMap": button_map,
+        "serverButtonMap": server_button_map,
+        "serverActions": {key: bool(value) for key, value in server_actions.items()},
+        "dpadMap": dpad_map,
+        "useDpad": bool(raw.get("useDpad", profile.get("useDpad", False))),
+    }
+
+
+def _safe_joystick_axis(joystick, axis_idx: int | None) -> float:
+    if axis_idx is None:
+        return 0.0
+    try:
+        if axis_idx < 0 or axis_idx >= joystick.get_numaxes():
+            return 0.0
+        return float(joystick.get_axis(axis_idx))
+    except Exception:
+        return 0.0
+
+
+def _safe_joystick_button(joystick, button_idx: int | None) -> bool:
+    if button_idx is None:
+        return False
+    try:
+        if button_idx < 0 or button_idx >= joystick.get_numbuttons():
+            return False
+        return bool(joystick.get_button(button_idx))
+    except Exception:
+        return False
+
+
+def _hid_hat_to_xy(hat: int) -> tuple[int, int]:
+    return {
+        0: (0, 1),
+        1: (1, 1),
+        2: (1, 0),
+        3: (1, -1),
+        4: (0, -1),
+        5: (-1, -1),
+        6: (-1, 0),
+        7: (-1, 1),
+    }.get(hat, (0, 0))
+
+
+def _safe_joystick_hat(joystick, hat_idx: int = 0) -> tuple[int, int]:
+    try:
+        if not hasattr(joystick, "get_numhats") or not hasattr(joystick, "get_hat"):
+            return (0, 0)
+        if hat_idx < 0 or hat_idx >= joystick.get_numhats():
+            return (0, 0)
+        x, y = joystick.get_hat(hat_idx)
+        return (
+            1 if int(x) > 0 else (-1 if int(x) < 0 else 0),
+            1 if int(y) > 0 else (-1 if int(y) < 0 else 0),
+        )
+    except Exception:
+        return (0, 0)
+
+
+def _apply_joystick_hat_nudge(
+    command: tuple[float, float, float], hat: tuple[int, int]
+) -> tuple[float, float, float]:
+    pan, tilt, zoom = command
+    hat_x, hat_y = hat
+    if hat_x:
+        pan = hat_x * JOYSTICK_HAT_NUDGE_SPEED
+    if hat_y:
+        tilt = hat_y * JOYSTICK_HAT_NUDGE_SPEED
+    return (
+        _quantize_joystick_axis(pan),
+        _quantize_joystick_axis(tilt),
+        _quantize_joystick_axis(zoom),
+    )
+
+
+def _apply_joystick_fine_control(
+    command: tuple[float, float, float], enabled: bool
+) -> tuple[float, float, float]:
+    if not enabled:
+        return command
+    return tuple(
+        _quantize_joystick_axis(axis * JOYSTICK_FINE_CONTROL_SCALE)
+        for axis in command
+    )
+
+
+def _read_server_joystick_command(
+    joystick, cfg: dict, axis_centers: dict[str, float] | None = None
+) -> tuple[float, float, float]:
+    deadzone = max(0.0, min(1.0, float(cfg.get("deadzone") or 0.2)))
+    sensitivity = cfg.get("sensitivity") or {}
+    axis_map = cfg.get("axisMap") or {}
+
+    if cfg.get("useDpad"):
+        dpad_map = cfg.get("dpadMap") or {}
+        left = _safe_joystick_button(joystick, dpad_map.get("left"))
+        right = _safe_joystick_button(joystick, dpad_map.get("right"))
+        up = _safe_joystick_button(joystick, dpad_map.get("up"))
+        down = _safe_joystick_button(joystick, dpad_map.get("down"))
+        pan = ((1.0 if right else 0.0) - (1.0 if left else 0.0)) * float(
+            sensitivity.get("pan") or 1.0
+        )
+        tilt = ((1.0 if down else 0.0) - (1.0 if up else 0.0)) * float(
+            sensitivity.get("tilt") or 1.0
+        )
+    else:
+        pan = _apply_joystick_deadzone(
+            _safe_joystick_axis(joystick, axis_map.get("pan")), deadzone
+        ) * float(sensitivity.get("pan") or 1.0)
+        tilt = _apply_joystick_deadzone(
+            _safe_joystick_axis(joystick, axis_map.get("tilt")), deadzone
+        ) * float(sensitivity.get("tilt") or 1.0)
+
+    raw_zoom = _safe_joystick_axis(joystick, axis_map.get("zoom"))
+    if axis_centers and "zoom" in axis_centers:
+        raw_zoom = _clamp_axis(raw_zoom - axis_centers["zoom"])
+    zoom = _apply_joystick_deadzone(raw_zoom, deadzone) * float(
+        sensitivity.get("zoom") or 0.5
+    )
+
+    return (
+        _quantize_joystick_axis(pan),
+        _quantize_joystick_axis(tilt),
+        _quantize_joystick_axis(zoom),
+    )
+
+
+def _camera_index_for_atem_source(settings: dict, source: int | None) -> int | None:
+    if source is None:
+        return None
+    for idx, cfg in enumerate(settings.get("cameras") or []):
+        if cfg.get("enabled") is False:
+            continue
+        try:
+            if int(cfg.get("atemInput", 0) or 0) == int(source):
+                return idx
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _server_joystick_target_cam(settings: dict) -> int:
+    active_cam = int(settings.get("activeCam", 0) or 0)
+    if settings.get("atem", {}).get("enabled"):
+        follows = _normalize_atem_follows(str(settings.get("atemFollows", "preview")))
+        if follows in {"preview", "program"}:
+            atem = _get_atem()
+            if atem.get("connected"):
+                followed_cam = _camera_index_for_atem_source(settings, atem.get(follows))
+                if followed_cam is not None:
+                    return followed_cam
+    return active_cam
+
+
+def _server_joystick_stop(cam_idx: int | None):
+    if cam_idx is None:
+        return
+    _execute_ptz_drive(cam_idx, 0.0, 0.0, 0.0)
+
+
+class _LogitechExtreme3DHidJoystick:
+    VENDOR_ID = 0x046D
+    PRODUCT_ID = 0xC215
+
+    def __init__(self):
+        import hid
+
+        devices = [
+            d
+            for d in hid.enumerate(self.VENDOR_ID, self.PRODUCT_ID)
+            if int(d.get("usage_page") or 0) == 1 and int(d.get("usage") or 0) == 4
+        ]
+        if not devices:
+            raise RuntimeError("Logitech Extreme 3D Pro HID device was not found")
+        self._hid = hid
+        self._device = hid.device()
+        self._device.open_path(devices[0]["path"])
+        self._device.set_nonblocking(True)
+        self._name = str(devices[0].get("product_string") or "Extreme 3D Pro")
+        self._axes = [0.0, 0.0, 0.0, 0.0]
+        self._buttons = [False] * 12
+        self._hat = (0, 0)
+        self._rz_center = None
+        self._rz_samples = []
+        self._rz_calibration_deadline = time.monotonic() + 1.0
+        self.pump()
+
+    def close(self):
+        try:
+            self._device.close()
+        except Exception:
+            pass
+
+    def get_name(self):
+        return self._name
+
+    def get_numaxes(self):
+        return len(self._axes)
+
+    def get_axis(self, axis_idx: int):
+        return self._axes[axis_idx]
+
+    def get_numbuttons(self):
+        return len(self._buttons)
+
+    def get_button(self, button_idx: int):
+        return self._buttons[button_idx]
+
+    def get_numhats(self):
+        return 1
+
+    def get_hat(self, hat_idx: int):
+        if hat_idx != 0:
+            return (0, 0)
+        return self._hat
+
+    def pump(self):
+        while True:
+            report = self._device.read(64)
+            if not report:
+                return
+            if len(report) < 7:
+                continue
+            x = int(report[0]) | ((int(report[1]) & 0x03) << 8)
+            y = (int(report[1]) >> 2) | ((int(report[2]) & 0x0F) << 6)
+            hat = (int(report[2]) >> 4) & 0x0F
+            rz = int(report[3])
+            slider = int(report[4])
+            buttons = int(report[5]) | ((int(report[6]) & 0x0F) << 8)
+            if self._rz_center is None:
+                self._rz_samples.append(rz)
+                still_calibrating = (
+                    time.monotonic() < self._rz_calibration_deadline
+                    or len(self._rz_samples) < 8
+                )
+                if still_calibrating:
+                    rz_axis = 0.0
+                else:
+                    sorted_samples = sorted(self._rz_samples)
+                    self._rz_center = sorted_samples[len(sorted_samples) // 2]
+                    _logger.info(
+                        "Joystick: calibrated twist center at raw value %s from samples %s",
+                        self._rz_center,
+                        self._rz_samples,
+                    )
+                    rz_axis = _normalize_hid_axis(rz, self._rz_center, 0, 255)
+            else:
+                rz_axis = _normalize_hid_axis(rz, self._rz_center, 0, 255)
+            self._axes = [
+                _normalize_hid_axis(x, 512, 0, 1023),
+                _normalize_hid_axis(y, 512, 0, 1023),
+                rz_axis,
+                _normalize_hid_axis(slider, 128, 0, 255),
+            ]
+            self._hat = _hid_hat_to_xy(hat)
+            self._buttons = [bool(buttons & (1 << idx)) for idx in range(12)]
+
+
+def _open_hid_joystick_for_config(cfg: dict):
+    if cfg.get("model") != "logitech-extreme-3d":
+        return None
+    return _LogitechExtreme3DHidJoystick()
+
+
+def _joystick_loop():
+    pygame = None
+    joystick = None
+    hid_joystick = None
+    hid_error = ""
+    joystick_index = 0
+    last_command = (0.0, 0.0, 0.0)
+    last_sent_command: tuple[float, float, float] | None = None
+    last_sent_cam: int | None = None
+    last_device_name = ""
+    last_attempt_command: tuple[int, tuple[float, float, float]] | None = None
+    last_attempt_at = 0.0
+    axis_centers: dict[str, float] = {}
+    zoom_center_samples: list[float] = []
+    zoom_center_deadline = 0.0
+    zoom_axis_active = False
+    fine_control_enabled = False
+    last_button_states: dict[str, bool] = {}
+
+    while True:
+        settings = load_settings()
+        cfg = _normalize_server_joystick_config(settings)
+        enabled = bool(cfg.get("enabled") and cfg.get("serverEnabled"))
+        if not enabled:
+            if last_sent_command != (0.0, 0.0, 0.0):
+                _server_joystick_stop(last_sent_cam)
+            if hid_joystick is not None:
+                hid_joystick.close()
+                hid_joystick = None
+            last_command = (0.0, 0.0, 0.0)
+            last_sent_command = None
+            last_sent_cam = None
+            axis_centers = {}
+            zoom_center_samples = []
+            zoom_center_deadline = 0.0
+            zoom_axis_active = False
+            fine_control_enabled = False
+            last_button_states = {}
+            _set_joystick_status(
+                enabled=bool(cfg.get("enabled")),
+                serverEnabled=bool(cfg.get("serverEnabled")),
+                available=pygame is not None,
+                connected=False,
+                device="",
+                message="Server joystick driver is disabled",
+                camIdx=None,
+                pan=0.0,
+                tilt=0.0,
+                zoom=0.0,
+                fineControl=False,
+                lastCommand=None,
+                lastError="",
+            )
+            time.sleep(0.5)
+            continue
+
+        if pygame is None:
+            try:
+                os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+                import pygame as _pygame
+
+                pygame = _pygame
+                pygame.init()
+                pygame.joystick.init()
+            except Exception as exc:
+                try:
+                    hid_joystick = _open_hid_joystick_for_config(cfg)
+                    hid_error = ""
+                    pygame = False
+                except Exception as hid_exc:
+                    _set_joystick_status(
+                        enabled=True,
+                        serverEnabled=True,
+                        available=False,
+                        connected=False,
+                        device="",
+                        message=(
+                            "Install pygame or hidapi for server joystick support: "
+                            f"pygame={exc}; hidapi={hid_exc}"
+                        ),
+                        camIdx=None,
+                        pan=0.0,
+                        tilt=0.0,
+                        zoom=0.0,
+                        fineControl=False,
+                        lastCommand=None,
+                        lastError=f"pygame={exc}; hidapi={hid_exc}",
+                    )
+                    time.sleep(2.0)
+                    continue
+
+        try:
+            if pygame:
+                pygame.event.pump()
+                count = pygame.joystick.get_count()
+            else:
+                count = 0
+            if count <= 0:
+                if hid_joystick is None:
+                    try:
+                        hid_joystick = _open_hid_joystick_for_config(cfg)
+                        hid_error = ""
+                    except Exception as exc:
+                        hid_error = str(exc)
+                if hid_joystick is not None:
+                    joystick = hid_joystick
+                    joystick.pump()
+                else:
+                    if last_sent_command != (0.0, 0.0, 0.0):
+                        _server_joystick_stop(last_sent_cam)
+                    joystick = None
+                    last_command = (0.0, 0.0, 0.0)
+                    last_sent_command = None
+                    fine_control_enabled = False
+                    last_button_states = {}
+                    message = "Server joystick enabled, waiting for device"
+                    if hid_error:
+                        message = f"{message}; HID fallback unavailable: {hid_error}"
+                    _set_joystick_status(
+                        enabled=True,
+                        serverEnabled=True,
+                        available=True,
+                        connected=False,
+                        device="",
+                        message=message,
+                        camIdx=None,
+                        pan=0.0,
+                        tilt=0.0,
+                        zoom=0.0,
+                        fineControl=False,
+                        lastCommand=None,
+                        lastError=hid_error,
+                    )
+                    time.sleep(0.5)
+                    continue
+            elif hid_joystick is not None:
+                hid_joystick.close()
+                hid_joystick = None
+
+            if hid_joystick is None and (joystick is None or joystick_index >= count):
+                joystick_index = 0
+                joystick = pygame.joystick.Joystick(joystick_index)
+                joystick.init()
+
+            cam_idx = _server_joystick_target_cam(settings)
+            command = _read_server_joystick_command(joystick, cfg, axis_centers)
+            device_name = joystick.get_name()
+            if device_name != last_device_name:
+                _logger.info("Joystick: connected to %s", device_name)
+                last_device_name = device_name
+                axis_centers = {}
+                zoom_center_samples = []
+                zoom_center_deadline = time.monotonic() + 1.0
+                zoom_axis_active = False
+                fine_control_enabled = False
+                last_button_states = {}
+            if cam_idx != last_sent_cam and last_sent_command != (0.0, 0.0, 0.0):
+                _server_joystick_stop(last_sent_cam)
+                last_sent_command = (0.0, 0.0, 0.0)
+
+            axis_map = cfg.get("axisMap") or {}
+            if "zoom" not in axis_centers:
+                raw_zoom = _safe_joystick_axis(joystick, axis_map.get("zoom"))
+                zoom_center_samples.append(raw_zoom)
+                still_calibrating = (
+                    time.monotonic() < zoom_center_deadline
+                    or len(zoom_center_samples) < 8
+                )
+                if still_calibrating:
+                    command = (command[0], command[1], 0.0)
+                    zoom_axis_active = False
+                else:
+                    sorted_samples = sorted(zoom_center_samples)
+                    axis_centers["zoom"] = sorted_samples[len(sorted_samples) // 2]
+                    _logger.info(
+                        "Joystick: calibrated zoom axis center at %.3f from samples %s",
+                        axis_centers["zoom"],
+                        [round(sample, 3) for sample in zoom_center_samples],
+                    )
+                    command = _read_server_joystick_command(
+                        joystick, cfg, axis_centers
+                    )
+
+            sensitivity = cfg.get("sensitivity") or {}
+            zoom, zoom_axis_active = _apply_zoom_start_hysteresis(
+                command[2],
+                max(0.0, min(1.0, float(cfg.get("deadzone") or 0.2))),
+                float(sensitivity.get("zoom") or 0.5),
+                zoom_axis_active,
+            )
+            command = (command[0], command[1], zoom)
+
+            server_actions = cfg.get("serverActions") or {}
+            server_button_map = cfg.get("serverButtonMap") or {}
+            trigger_action_enabled = bool(server_actions.get("triggerStop", True))
+            fine_action_enabled = bool(server_actions.get("thumbFine", True))
+            hat_action_enabled = bool(server_actions.get("hatNudge", True))
+
+            trigger_pressed = _safe_joystick_button(
+                joystick, server_button_map.get("triggerStop")
+            )
+            fine_button_pressed = _safe_joystick_button(
+                joystick, server_button_map.get("toggleFine")
+            )
+            if fine_action_enabled:
+                fine_was_pressed = last_button_states.get("toggleFine", False)
+                if fine_button_pressed and not fine_was_pressed:
+                    fine_control_enabled = not fine_control_enabled
+                    _logger.info(
+                        "Joystick: fine control %s",
+                        "enabled" if fine_control_enabled else "disabled",
+                    )
+            else:
+                fine_control_enabled = False
+            last_button_states["toggleFine"] = fine_button_pressed
+
+            if hat_action_enabled:
+                command = _apply_joystick_hat_nudge(
+                    command, _safe_joystick_hat(joystick)
+                )
+            command = _apply_joystick_fine_control(command, fine_control_enabled)
+
+            trigger_was_pressed = last_button_states.get("triggerStop", False)
+            if trigger_action_enabled and trigger_pressed:
+                if not trigger_was_pressed:
+                    _logger.info("Joystick: trigger stop")
+                command = (0.0, 0.0, 0.0)
+                zoom_axis_active = False
+            last_button_states["triggerStop"] = trigger_pressed
+
+            now = time.monotonic()
+            should_send = command != last_sent_command or cam_idx != last_sent_cam
+            should_retry = (
+                last_attempt_command != (cam_idx, command)
+                or now - last_attempt_at >= JOYSTICK_ERROR_RETRY_INTERVAL_S
+            )
+            if should_send and should_retry:
+                last_attempt_command = (cam_idx, command)
+                last_attempt_at = now
+                status, response = _execute_ptz_drive(cam_idx, *command)
+                if 200 <= status < 300 and response.get("ok"):
+                    last_sent_command = command
+                    last_sent_cam = cam_idx
+                else:
+                    error_message = response.get("error") or "PTZ move failed"
+                    _logger.warning(
+                        "Joystick: command blocked/failed cam=%s pan=%.2f tilt=%.2f zoom=%.2f: %s",
+                        cam_idx + 1,
+                        command[0],
+                        command[1],
+                        command[2],
+                        error_message,
+                    )
+                    _set_joystick_status(
+                        enabled=True,
+                        serverEnabled=True,
+                        available=True,
+                        connected=True,
+                        device=device_name,
+                        message=error_message,
+                        camIdx=cam_idx,
+                        pan=command[0],
+                        tilt=command[1],
+                        zoom=command[2],
+                        fineControl=fine_control_enabled,
+                        lastCommand={
+                            "camIdx": cam_idx,
+                            "pan": command[0],
+                            "tilt": command[1],
+                            "zoom": command[2],
+                            "ok": False,
+                            "status": status,
+                            "message": error_message,
+                        },
+                        lastError=error_message,
+                    )
+                    time.sleep(JOYSTICK_COMMAND_INTERVAL_S)
+                    continue
+
+            if command != last_command:
+                last_command = command
+                _logger.info(
+                    "Joystick: input cam=%s pan=%.2f tilt=%.2f zoom=%.2f",
+                    cam_idx + 1,
+                    command[0],
+                    command[1],
+                    command[2],
+                )
+            message = (
+                "Server joystick input idle"
+                if command == (0.0, 0.0, 0.0)
+                else "Server joystick sending PTZ input"
+            )
+            _set_joystick_status(
+                enabled=True,
+                serverEnabled=True,
+                available=True,
+                connected=True,
+                device=device_name,
+                message=message,
+                camIdx=cam_idx,
+                pan=command[0],
+                tilt=command[1],
+                zoom=command[2],
+                fineControl=fine_control_enabled,
+                lastCommand={
+                    "camIdx": cam_idx,
+                    "pan": command[0],
+                    "tilt": command[1],
+                    "zoom": command[2],
+                    "ok": last_sent_command == command and last_sent_cam == cam_idx,
+                    "status": 200,
+                    "message": message,
+                },
+                lastError="",
+            )
+            time.sleep(JOYSTICK_POLL_INTERVAL_S)
+        except Exception as exc:
+            if last_sent_command != (0.0, 0.0, 0.0):
+                _server_joystick_stop(last_sent_cam)
+            joystick = None
+            last_sent_command = None
+            last_device_name = ""
+            fine_control_enabled = False
+            last_button_states = {}
+            _logger.warning("Joystick: error: %r", exc)
+            _set_joystick_status(
+                enabled=True,
+                serverEnabled=True,
+                available=True,
+                connected=False,
+                device="",
+                message=f"Server joystick error: {exc}",
+                camIdx=None,
+                pan=0.0,
+                tilt=0.0,
+                zoom=0.0,
+                fineControl=False,
+                lastCommand=None,
+                lastError=str(exc),
+            )
+            time.sleep(1.0)
+
+
 # ── HTTP handler ───────────────────────────────────────────────────────────────
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):  # noqa: A002
@@ -1879,6 +2784,8 @@ class Handler(BaseHTTPRequestHandler):
             self._sse()
         elif path == "/api/devices":
             self._json(200, list_usb_devices())
+        elif path == "/api/joystick/status":
+            self._json(200, _get_joystick_status())
         elif path == "/api/system":
             self._json(
                 200,
@@ -2012,92 +2919,8 @@ class Handler(BaseHTTPRequestHandler):
             self._json(400, {"ok": False, "error": "Invalid PTZ command payload"})
             return
 
-        settings = load_settings()
-        cameras = settings.get("cameras") or []
-        if cam_idx < 0 or cam_idx >= len(cameras):
-            self._json(404, {"ok": False, "error": "Camera not found"})
-            return
-
-        cfg = cameras[cam_idx] or {}
-        ip = str(cfg.get("ip", "")).strip()
-        if not ip:
-            self._json(400, {"ok": False, "error": "Camera IP is required"})
-            return
-
-        is_stop = pan == 0 and tilt == 0 and zoom == 0
-        if not is_stop:
-            block_reason = _live_movement_block_reason(settings, cam_idx, cfg)
-            if block_reason:
-                if block_reason == "Protected live camera is on ATEM program.":
-                    block_reason = (
-                        "Protected live camera is on ATEM program. Switch cameras "
-                        "or turn off Protect Live Camera before moving."
-                    )
-                self._json(409, {"ok": False, "error": block_reason})
-                return
-
-        with _get_ptz_camera_lock(cam_idx):
-            fresh, last_seen = _claim_ptz_command_id(cam_idx, command_id)
-            if not fresh:
-                self._json(
-                    200,
-                    {
-                        "ok": True,
-                        "stale": True,
-                        "commandId": command_id,
-                        "lastCommandId": last_seen,
-                        "camIdx": cam_idx,
-                        "pan": pan,
-                        "tilt": tilt,
-                        "zoom": zoom,
-                    },
-                )
-                return
-
-            port = int(cfg.get("port", 52381) or 52381)
-            visca_addr = int(cfg.get("viscaAddr", 1) or 1)
-            deadzone = 0.20
-            pan_mag = abs(pan)
-            tilt_mag = abs(tilt)
-            pan_dir = 0x03 if pan_mag < deadzone else (0x01 if pan < 0 else 0x02)
-            tilt_dir = 0x03 if tilt_mag < deadzone else (0x01 if tilt > 0 else 0x02)
-            pan_speed = (
-                1 if pan_dir == 0x03 else max(1, min(0x10, int(round(pan_mag * 0x10))))
-            )
-            tilt_speed = (
-                1
-                if tilt_dir == 0x03
-                else max(1, min(0x10, int(round(tilt_mag * 0x10))))
-            )
-
-            pt_ok, pt_message = send_camera_pan_tilt_drive(
-                ip,
-                port,
-                pan_speed,
-                tilt_speed,
-                pan_dir,
-                tilt_dir,
-                camera_address=visca_addr,
-                cfg=cfg,
-            )
-            zoom_ok, zoom_message = send_camera_zoom_drive(
-                ip, port, zoom, camera_address=visca_addr, cfg=cfg
-            )
-            ok = pt_ok and zoom_ok
-        self._json(
-            200 if ok else 502,
-            {
-                "ok": ok,
-                "stale": False,
-                "commandId": command_id,
-                "camIdx": cam_idx,
-                "pan": pan,
-                "tilt": tilt,
-                "zoom": zoom,
-                "panTiltMessage": pt_message,
-                "zoomMessage": zoom_message,
-            },
-        )
+        status, response = _execute_ptz_drive(cam_idx, pan, tilt, zoom, command_id)
+        self._json(status, response)
 
     def _handle_atem_cut(self):
         """
@@ -2651,6 +3474,10 @@ if __name__ == "__main__":
         )
     atem_thread = threading.Thread(target=_atem_loop, daemon=True, name="atem")
     atem_thread.start()
+    joystick_thread = threading.Thread(
+        target=_joystick_loop, daemon=True, name="joystick"
+    )
+    joystick_thread.start()
     host, port = "0.0.0.0", 5001
     httpd = ThreadedHTTPServer((host, port), Handler)
     logger.info(f"PTZ Preset Control listening on http://localhost:{port}")

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -237,6 +237,14 @@ class TestFrontendContracts(unittest.TestCase):
         self.assertIn("function normalizeVirtualJoystickSettings(value)", self.html)
         self.assertIn("joystick: normalizeJoystickSettings(),", self.html)
         self.assertIn("virtualJoystick: normalizeVirtualJoystickSettings(),", self.html)
+        self.assertIn('id="f-joystick-server-enabled"', self.html)
+        self.assertIn('id="f-joystick-trigger-stop"', self.html)
+        self.assertIn('id="f-joystick-thumb-fine"', self.html)
+        self.assertIn('id="f-joystick-hat-nudge"', self.html)
+        self.assertIn('id="joystick-server-status-text"', self.html)
+        self.assertIn("serverEnabled: false,", self.html)
+        self.assertIn("serverActions: { triggerStop: true, thumbFine: true, hatNudge: true }", self.html)
+        self.assertIn("function refreshServerJoystickStatus()", self.html)
         self.assertIn(
             "if (s.joystick) state.joystick = normalizeJoystickSettings(s.joystick);",
             self.html,
@@ -254,6 +262,8 @@ class TestFrontendContracts(unittest.TestCase):
             self.html,
         )
         self.assertIn("state.joystick = normalizeJoystickSettings({", self.html)
+        self.assertIn("serverEnabled: elJoystickServerEnabled?.checked || false,", self.html)
+        self.assertIn("triggerStop: elJoystickTriggerStop?.checked !== false,", self.html)
 
     def test_virtual_joystick_response_curve_and_snapback_guard_present(self):
         self.assertIn("let lastVirtualJoystickCommand = { pan: 0, tilt: 0 };", self.html)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -385,6 +385,80 @@ class TestDefaultSettings(unittest.TestCase):
             )
 
 
+class TestJoystickAxisHelpers(unittest.TestCase):
+    def test_normalize_hid_axis_uses_calibrated_center(self):
+        self.assertEqual(server._normalize_hid_axis(92, 92, 0, 255), 0.0)
+        self.assertGreater(server._normalize_hid_axis(170, 92, 0, 255), 0)
+        self.assertLess(server._normalize_hid_axis(40, 92, 0, 255), 0)
+
+    def test_normalize_hid_axis_handles_asymmetric_span(self):
+        self.assertAlmostEqual(server._normalize_hid_axis(255, 92, 0, 255), 1.0)
+        self.assertAlmostEqual(server._normalize_hid_axis(0, 92, 0, 255), -1.0)
+
+    def test_hid_hat_to_xy_maps_cardinal_and_neutral_values(self):
+        self.assertEqual(server._hid_hat_to_xy(0), (0, 1))
+        self.assertEqual(server._hid_hat_to_xy(2), (1, 0))
+        self.assertEqual(server._hid_hat_to_xy(4), (0, -1))
+        self.assertEqual(server._hid_hat_to_xy(6), (-1, 0))
+        self.assertEqual(server._hid_hat_to_xy(8), (0, 0))
+
+    def test_hat_nudge_sets_pan_tilt_without_changing_zoom(self):
+        command = server._apply_joystick_hat_nudge((0.0, 0.0, -0.5), (1, -1))
+        self.assertAlmostEqual(command[0], 0.35)
+        self.assertAlmostEqual(command[1], -0.35)
+        self.assertAlmostEqual(command[2], -0.5)
+
+    def test_fine_control_scales_command(self):
+        command = server._apply_joystick_fine_control((1.0, -0.4, 0.4), True)
+        self.assertAlmostEqual(command[0], 0.35)
+        self.assertAlmostEqual(command[1], -0.15)
+        self.assertAlmostEqual(command[2], 0.15)
+
+    def test_server_joystick_command_applies_zoom_center(self):
+        class FakeJoystick:
+            def get_numaxes(self):
+                return 3
+
+            def get_axis(self, axis_idx):
+                return {0: 0.0, 1: 0.0, 2: -0.7}[axis_idx]
+
+            def get_numbuttons(self):
+                return 0
+
+        cfg = {
+            "deadzone": 0.2,
+            "sensitivity": {"pan": 1.0, "tilt": 1.0, "zoom": 0.5},
+            "axisMap": {"pan": 0, "tilt": 1, "zoom": 2},
+            "useDpad": False,
+        }
+
+        self.assertEqual(
+            server._read_server_joystick_command(
+                FakeJoystick(), cfg, {"zoom": -0.7}
+            ),
+            (0.0, 0.0, 0.0),
+        )
+
+    def test_zoom_hysteresis_suppresses_idle_drift(self):
+        zoom, active = server._apply_zoom_start_hysteresis(
+            0.15, deadzone=0.25, sensitivity=0.5, active=False
+        )
+        self.assertEqual(zoom, 0.0)
+        self.assertFalse(active)
+
+    def test_zoom_hysteresis_allows_deliberate_twist_and_stops_at_zero(self):
+        zoom, active = server._apply_zoom_start_hysteresis(
+            0.2, deadzone=0.25, sensitivity=0.5, active=False
+        )
+        self.assertEqual(zoom, 0.2)
+        self.assertTrue(active)
+        zoom, active = server._apply_zoom_start_hysteresis(
+            0.0, deadzone=0.25, sensitivity=0.5, active=True
+        )
+        self.assertEqual(zoom, 0.0)
+        self.assertFalse(active)
+
+
 # ── VISCA packet construction ──────────────────────────────────────────────────
 
 
@@ -872,6 +946,22 @@ class TestHTTPRoutes(unittest.TestCase):
             data["cameras"][0]["cameraModel"], server.DEFAULT_CAMERA_MODEL
         )
 
+    def test_get_joystick_status_returns_server_driver_state(self):
+        server._set_joystick_status(
+            enabled=True,
+            serverEnabled=True,
+            available=False,
+            connected=False,
+            message="Install pygame for server joystick support",
+        )
+        status, body = self.srv.get("/api/joystick/status")
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertTrue(data["enabled"])
+        self.assertTrue(data["serverEnabled"])
+        self.assertFalse(data["available"])
+        self.assertIn("pygame", data["message"])
+
     def test_post_settings_bad_json_returns_400(self):
         status, body = self.srv.post("/settings", b"not json")
         self.assertEqual(status, 400)
@@ -1021,7 +1111,7 @@ class TestHTTPRoutes(unittest.TestCase):
             patch(
                 "server.send_camera_pan_tilt_drive", return_value=(True, "pt ok")
             ) as mock_pt,
-            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok")),
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok")) as mock_zoom,
         ):
             first_status, _ = self.srv.post("/api/ptz/drive", first)
             stale_status, stale_body = self.srv.post("/api/ptz/drive", stale)
@@ -1034,6 +1124,7 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertEqual(stale_data["commandId"], 499)
         self.assertEqual(stale_data["lastCommandId"], 500)
         self.assertEqual(mock_pt.call_count, 1)
+        self.assertEqual(mock_zoom.call_count, 0)
 
     def test_ptz_drive_applies_newer_command_ids(self):
         settings = dict(server.DEFAULT_SETTINGS)
@@ -1063,6 +1154,113 @@ class TestHTTPRoutes(unittest.TestCase):
         self.assertFalse(data["stale"])
         self.assertEqual(data["commandId"], 501)
         self.assertEqual(mock_pt.call_count, 2)
+
+    def test_ptz_drive_does_not_send_unchanged_zoom_stop_after_pan(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(server.DEFAULT_SETTINGS["cameras"][0], ip="10.0.0.1")
+        ]
+        server.write_settings(settings)
+        payload = json.dumps(
+            {"camIdx": 0, "pan": 0.7, "tilt": 0, "zoom": 0, "commandId": 900}
+        ).encode()
+
+        with (
+            patch("server.send_camera_pan_tilt_drive", return_value=(True, "pt ok"))
+            as mock_pt,
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok"))
+            as mock_zoom,
+        ):
+            status, body = self.srv.post("/api/ptz/drive", payload)
+
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body)["ok"])
+        mock_pt.assert_called_once()
+        mock_zoom.assert_not_called()
+
+    def test_ptz_drive_sends_zoom_stop_after_prior_zoom(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(server.DEFAULT_SETTINGS["cameras"][0], ip="10.0.0.1")
+        ]
+        server.write_settings(settings)
+        zoom_in = json.dumps(
+            {"camIdx": 0, "pan": 0, "tilt": 0, "zoom": 0.6, "commandId": 901}
+        ).encode()
+        zoom_stop = json.dumps(
+            {"camIdx": 0, "pan": 0, "tilt": 0, "zoom": 0, "commandId": 902}
+        ).encode()
+
+        with (
+            patch("server.send_camera_pan_tilt_drive", return_value=(True, "pt ok"))
+            as mock_pt,
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok"))
+            as mock_zoom,
+        ):
+            first_status, _ = self.srv.post("/api/ptz/drive", zoom_in)
+            stop_status, stop_body = self.srv.post("/api/ptz/drive", zoom_stop)
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(stop_status, 200)
+        self.assertTrue(json.loads(stop_body)["ok"])
+        mock_pt.assert_not_called()
+        self.assertEqual(mock_zoom.call_count, 2)
+
+    def test_ptz_drive_resends_pan_tilt_stop_after_prior_movement(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(server.DEFAULT_SETTINGS["cameras"][0], ip="10.0.0.1")
+        ]
+        server.write_settings(settings)
+        move = json.dumps(
+            {"camIdx": 0, "pan": 0.6, "tilt": 0, "zoom": 0, "commandId": 903}
+        ).encode()
+        stop = json.dumps(
+            {"camIdx": 0, "pan": 0, "tilt": 0, "zoom": 0, "commandId": 904}
+        ).encode()
+
+        with (
+            patch("server.send_camera_pan_tilt_drive", return_value=(True, "pt ok"))
+            as mock_pt,
+            patch("server.send_camera_zoom_drive", return_value=(True, "zoom ok"))
+            as mock_zoom,
+        ):
+            first_status, _ = self.srv.post("/api/ptz/drive", move)
+            stop_status, stop_body = self.srv.post("/api/ptz/drive", stop)
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(stop_status, 200)
+        self.assertTrue(json.loads(stop_body)["ok"])
+        self.assertEqual(mock_pt.call_count, 2)
+        mock_zoom.assert_not_called()
+
+    def test_ptz_drive_retries_stop_without_ack_up_to_limit(self):
+        settings = dict(server.DEFAULT_SETTINGS)
+        settings["cameras"] = [
+            dict(server.DEFAULT_SETTINGS["cameras"][0], ip="10.0.0.1")
+        ]
+        server.write_settings(settings)
+        zoom_in = json.dumps(
+            {"camIdx": 0, "pan": 0, "tilt": 0, "zoom": 0.6, "commandId": 905}
+        ).encode()
+        zoom_stop = json.dumps(
+            {"camIdx": 0, "pan": 0, "tilt": 0, "zoom": 0, "commandId": 906}
+        ).encode()
+
+        with (
+            patch("server.send_camera_pan_tilt_drive", return_value=(True, "pt ok")),
+            patch(
+                "server.send_camera_zoom_drive",
+                return_value=(True, "Command sent (no VISCA response received)"),
+            ) as mock_zoom,
+        ):
+            first_status, _ = self.srv.post("/api/ptz/drive", zoom_in)
+            stop_status, stop_body = self.srv.post("/api/ptz/drive", zoom_stop)
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(stop_status, 200)
+        self.assertTrue(json.loads(stop_body)["ok"])
+        self.assertEqual(mock_zoom.call_count, 1 + server.PTZ_STOP_MAX_ATTEMPTS)
 
     def test_post_image_live_protection_returns_409_when_target_camera_is_on_program(
         self,


### PR DESCRIPTION
## Summary

Adds Python-server joystick support and server-side controls for the Logitech Extreme 3D Pro.

- Maps trigger to immediate PTZ stop, thumb button to fine-control toggle, and hat switch to pan/tilt nudge
- Adds settings checkboxes to disable those server-side mappings individually
- Reports server joystick status, active fine-control state, and command diagnostics to the UI
- Updates joystick setup documentation and test coverage

## Validation

- `python3 -m py_compile server.py`
- `uv run ruff check server.py tests/test_server.py tests/test_frontend_contracts.py`
- `uv run pytest tests/test_server.py tests/test_frontend_contracts.py`